### PR TITLE
Add live ZIP code lookup endpoint

### DIFF
--- a/moontide-proxy/README.md
+++ b/moontide-proxy/README.md
@@ -24,11 +24,19 @@ The server will run on `http://localhost:3001` by default.
 
 ## Usage
 
-The proxy exposes a single endpoint:
+The proxy exposes two endpoints:
 
 ```
 GET /api/noaa?url=<NOAA_FULL_URL>
 ```
+
+### ZIP Code Lookup
+
+```
+GET /api/zip-lookup?zip=<ZIPCODE>
+```
+
+This endpoint forwards the request to `https://api.zippopotam.us/us/<ZIPCODE>` and returns the JSON response.
 
 ### Example
 


### PR DESCRIPTION
## Summary
- add `/api/zip-lookup` endpoint in `moontide-proxy/server.ts` to query zippopotam.us
- document the new endpoint in `moontide-proxy/README.md`

## Testing
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68596e908d78832da5347b7ba43a7197