### PR TITLE
Route zip lookups through backend

### DIFF
--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -7,7 +7,7 @@ interface GeocodeResult {
   state: string;
 }
 
-const GEOCODING_API_BASE = 'https://api.zippopotam.us/us/';
+const GEOCODING_API_BASE = '/api/zip-lookup?zip=';
 const ZIP_CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
 const CITY_CACHE_TTL = 24 * 60 * 60 * 1000; // 1 day
 
@@ -24,9 +24,9 @@ export async function getCoordinatesForZip(zipCode: string): Promise<GeocodeResu
   }
   
   
-  // Try the free geocoding API
+  // Query the backend for ZIP geocoding
   try {
-    console.log(`🌐 Fetching coordinates from geocoding API for ZIP: ${zipCode}`);
+    console.log(`🌐 Fetching coordinates from backend API for ZIP: ${zipCode}`);
     const response = await fetch(`${GEOCODING_API_BASE}${zipCode}`);
     
     if (!response.ok) {

--- a/src/utils/zipCodeLookup.ts
+++ b/src/utils/zipCodeLookup.ts
@@ -72,8 +72,8 @@ export const lookupZipCode = async (
 
   // ── 3. REMOTE LOOK-UP ────────────────────────────────────
   try {
-    console.log(`🌐 Fetching ZIP ${cleanZip} from remote API`);
-    const res = await fetch(`https://api.zippopotam.us/us/${cleanZip}`);
+    console.log(`🌐 Fetching ZIP ${cleanZip} from backend API`);
+    const res = await fetch(`/api/zip-lookup?zip=${cleanZip}`);
     if (!res.ok) return null;
 
     const data = (await res.json()) as ZipApiResponse;


### PR DESCRIPTION
## Summary
- update geocodingService to use `/api/zip-lookup` instead of calling zippopotam.us directly
- update zipCodeLookup utility to hit backend endpoint

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685972df7a44832dacd6dd61f8b6eceb