### PR TITLE
Remove direct references to external ZIP APIs

### DIFF
--- a/moontide-proxy/README.md
+++ b/moontide-proxy/README.md
@@ -36,7 +36,7 @@ GET /api/noaa?url=<NOAA_FULL_URL>
 GET /api/zip-lookup?zip=<ZIPCODE>
 ```
 
-This endpoint forwards the request to `https://api.zippopotam.us/us/<ZIPCODE>` and returns the JSON response.
+This endpoint queries the external ZIP service and returns the JSON response.
 
 ### Example
 

--- a/src/utils/zipCodeLookup.ts
+++ b/src/utils/zipCodeLookup.ts
@@ -1,7 +1,7 @@
 import { safeLocalStorage } from '@/utils/localStorage';
 import { cacheService } from '@/services/cacheService';
 
-/** zippopotam.us response shape (minimal) */
+/** /api/zip-lookup response shape (compatible with zippopotam.us) */
 interface ZipApiResponse {
   'post code': string;
   country: string;


### PR DESCRIPTION
## Summary
- document the /api/zip-lookup response interface in zipCodeLookup utils
- clarify proxy README to not mention the external domain

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_685990b0e81c832daa7e33da2263eeba