### PR TITLE
Add NOAA station search and tide endpoints

### DIFF
--- a/moontide-proxy/noaaStations.ts
+++ b/moontide-proxy/noaaStations.ts
@@ -1,0 +1,118 @@
+import { Router } from 'express';
+import axios from 'axios';
+
+const router = Router();
+const STATIONS_URL = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json';
+
+interface StationMeta {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  state?: string;
+}
+
+let stationCache: StationMeta[] | null = null;
+
+async function loadStations(): Promise<StationMeta[]> {
+  if (stationCache) {
+    return stationCache;
+  }
+  const res = await axios.get(STATIONS_URL);
+  const data = res.data;
+  if (Array.isArray(data?.stations)) {
+    stationCache = data.stations
+      .filter((s: any) => s.lat && s.lng && s.id && s.name)
+      .map((s: any) => ({
+        id: String(s.id),
+        name: s.name,
+        lat: parseFloat(s.lat),
+        lng: parseFloat(s.lng),
+        state: s.state,
+      }));
+  } else {
+    stationCache = [];
+  }
+  return stationCache ?? [];
+}
+
+function haversine(lat1: number, lon1: number, lat2: number, lon2: number) {
+  const R = 6371;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+    Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+async function geocode(input: string): Promise<{ lat: number; lng: number } | null> {
+  const coordMatch = input.match(/^\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)\s*$/);
+  if (coordMatch) {
+    const lat = parseFloat(coordMatch[1]);
+    const lng = parseFloat(coordMatch[2]);
+    return { lat, lng };
+  }
+
+  if (/^\d{5}$/.test(input.trim())) {
+    try {
+      const res = await axios.get(`https://api.zippopotam.us/us/${input.trim()}`);
+      const place = res.data.places?.[0];
+      if (place) {
+        return { lat: parseFloat(place.latitude), lng: parseFloat(place.longitude) };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const res = await axios.get('https://nominatim.openstreetmap.org/search', {
+      params: { q: input, format: 'json', limit: 1 },
+      headers: { 'User-Agent': 'lunar-wave-watcher' }
+    });
+    const loc = res.data[0];
+    if (loc) {
+      return { lat: parseFloat(loc.lat), lng: parseFloat(loc.lon) };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+router.get('/api/noaa-stations', async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  const input = (req.query.locationInput as string) || '';
+  if (!input) {
+    res.status(400).json({ error: 'Missing locationInput' });
+    return;
+  }
+
+  try {
+    const coords = await geocode(input);
+    if (!coords) {
+      res.status(400).json({ error: 'Unable to resolve location' });
+      return;
+    }
+    const stations = await loadStations();
+    const results = stations
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        latitude: s.lat,
+        longitude: s.lng,
+        state: s.state,
+        distance: haversine(coords.lat, coords.lng, s.lat, s.lng),
+      }))
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, 10);
+    res.json({ stations: results });
+  } catch (err) {
+    console.error('Station lookup error:', err);
+    res.status(500).json({ error: 'Failed to fetch stations' });
+  }
+});
+
+export default router;

--- a/moontide-proxy/server.ts
+++ b/moontide-proxy/server.ts
@@ -11,7 +11,8 @@ app.get('/api/noaa', async (req, res) => {
   const { url } = req.query;
 
   if (!url || typeof url !== 'string') {
-    return res.status(400).json({ error: 'Missing or invalid NOAA API URL' });
+    res.status(400).json({ error: 'Missing or invalid NOAA API URL' });
+    return;
   }
 
   try {

--- a/moontide-proxy/tides.ts
+++ b/moontide-proxy/tides.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import axios from 'axios';
+
+const router = Router();
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}${m}${day}`;
+}
+
+router.get('/api/tides', async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  const locationInput = req.query.locationInput as string | undefined; // not used but required by interface
+  const stationId = req.query.stationId as string | undefined;
+
+  if (!locationInput || !stationId) {
+    res.status(400).json({ error: 'Missing locationInput or stationId' });
+    return;
+  }
+
+  const start = new Date();
+  const end = new Date();
+  end.setDate(start.getDate() + 6);
+
+  const params = new URLSearchParams({
+    product: 'predictions',
+    application: 'LunarWaveWatcher',
+    format: 'json',
+    datum: 'MLLW',
+    time_zone: 'lst_ldt',
+    units: 'english',
+    station: stationId,
+    begin_date: formatDate(start),
+    end_date: formatDate(end)
+  });
+
+  const url = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?${params.toString()}`;
+
+  try {
+    const response = await axios.get(url);
+    res.json(response.data);
+  } catch (err) {
+    console.error('Tide fetch error:', err);
+    res.status(500).json({ error: 'Failed to fetch tide data' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `/api/noaa-stations` endpoint to look up nearby tide stations
- add `/api/tides` endpoint to fetch tide predictions
- adjust proxy server return logic for TypeScript

## Testing
- `npm run type-check` in `moontide-proxy`

------
https://chatgpt.com/codex/tasks/task_e_685aa76889d4832d86b3072e2c717cba