### PR TITLE
Integrate NOAA stations router and add logging

### DIFF
--- a/moontide-proxy/server.ts
+++ b/moontide-proxy/server.ts
@@ -1,14 +1,17 @@
 import express from 'express';
 import axios from 'axios';
 import cors from 'cors';
+import stationsRouter from './noaaStations';
 
 const app = express();
 const PORT = 3001;
 
 app.use(cors());
+app.use(stationsRouter);
 
 app.get('/api/noaa', async (req, res) => {
   const { url } = req.query;
+  console.log('NOAA proxy request:', url);
 
   if (!url || typeof url !== 'string') {
     res.status(400).json({ error: 'Missing or invalid NOAA API URL' });
@@ -17,12 +20,13 @@ app.get('/api/noaa', async (req, res) => {
 
   try {
     const response = await axios.get(url);
+    console.log('NOAA proxy success for', url);
     res.json(response.data);
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.error("NOAA proxy error:", error.message);
+      console.error('NOAA proxy error:', error.message);
     } else {
-      console.error("NOAA proxy error:", error);
+      console.error('NOAA proxy error:', error);
     }
     res.status(500).json({ error: 'Failed to fetch from NOAA API' });
   }


### PR DESCRIPTION
## Summary
- wire up `noaaStations` router in `server.ts`
- log incoming NOAA proxy requests
- log NOAA station router requests
- log station list loading and geocode attempts/results

## Testing
- `npm run lint` *(fails: type errors and lint issues)*
- `npx tsc -p moontide-proxy/tsconfig.json` *(fails: cannot find modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ac19c3ea0832dbc61c48a980b7fa9