### PR TITLE
Refactor Moontide proxy endpoints

### DIFF
--- a/moontide-proxy/noaaStations.ts
+++ b/moontide-proxy/noaaStations.ts
@@ -93,10 +93,10 @@ async function geocode(input: string): Promise<{ lat: number; lng: number } | nu
   return null;
 }
 
-router.get('/api/noaa-stations', async (req, res) => {
+router.get('/noaa-stations', async (req, res) => {
   res.set('Access-Control-Allow-Origin', '*');
   const input = (req.query.locationInput as string) || '';
-  console.log('/api/noaa-stations request:', input);
+  console.log('/noaa-stations request:', input);
   if (!input) {
     res.status(400).json({ error: 'Missing locationInput' });
     return;

--- a/moontide-proxy/server.ts
+++ b/moontide-proxy/server.ts
@@ -2,12 +2,14 @@ import express from 'express';
 import axios from 'axios';
 import cors from 'cors';
 import stationsRouter from './noaaStations';
+import tidesRouter from './tides';
 
 const app = express();
 const PORT = 3001;
 
 app.use(cors());
 app.use(stationsRouter);
+app.use(tidesRouter);
 
 app.get('/api/noaa', async (req, res) => {
   const { url } = req.query;

--- a/moontide-proxy/tides.ts
+++ b/moontide-proxy/tides.ts
@@ -10,7 +10,7 @@ function formatDate(d: Date): string {
   return `${y}${m}${day}`;
 }
 
-router.get('/api/tides', async (req, res) => {
+router.get('/tides', async (req, res) => {
   res.set('Access-Control-Allow-Origin', '*');
   const locationInput = req.query.locationInput as string | undefined; // not used but required by interface
   const stationId = req.query.stationId as string | undefined;

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -16,7 +16,7 @@ export async function getStationsForLocation(
   userInput: string
 ): Promise<Station[]> {
   const response = await fetch(
-    `/api/noaa-stations?locationInput=${encodeURIComponent(userInput)}`
+    `/noaa-stations?locationInput=${encodeURIComponent(userInput)}`
   );
   if (!response.ok) throw new Error("Unable to fetch station list.");
   const data = await response.json();

--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -3,7 +3,7 @@
 // Fetches 7-day tide data for the selected location and station from backend
 export async function getTideData(locationInput: string, stationId: string) {
   const response = await fetch(
-    `/api/tides?locationInput=${encodeURIComponent(locationInput)}&stationId=${encodeURIComponent(stationId)}`
+    `/tides?locationInput=${encodeURIComponent(locationInput)}&stationId=${encodeURIComponent(stationId)}`
   );
   if (!response.ok) throw new Error("Unable to fetch tide data.");
   const data = await response.json();


### PR DESCRIPTION
## Summary
- remove `/api` prefix from NOAA proxy routes
- mount tide route in server
- update front-end service paths

## Testing
- `npm run lint` *(fails: unexpected any & require import issues)*
- `npx tsx server.ts` then `curl http://localhost:3001/noaa-stations?locationInput=02882`
- `curl http://localhost:3001/tides?locationInput=02882&stationId=8452660`


------
https://chatgpt.com/codex/tasks/task_e_685acdfa1f7c832da1ee4c04dbb75b29