### PR TITLE
Fix stationId for tide fetch

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -71,15 +71,21 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
           return;
         }
 
-        // Otherwise, fetch tide data for the selected station
-        const stationId = location.id;
-        const result = await getTideData(location.name, stationId);
+        // Otherwise, fetch tide data for the nearest station
+        const station = stations[0];
+        if (!station?.id) {
+          console.warn('No station ID available for location', location);
+          setIsLoading(false);
+          return;
+        }
+        const dateIso = new Date().toISOString().split('T')[0];
+        const result = await getTideData(station.id, dateIso);
 
         setTideData(result.data?.tideData || []);
         setWeeklyForecast(result.data?.weeklyForecast || []);
         setCurrentDate(result.data?.currentDate || getCurrentDateString());
         setCurrentTime(result.data?.currentTime || getCurrentTimeString());
-        setStationName(result.data?.stationName || location.name || null);
+        setStationName(result.data?.stationName || station.name || location.name || null);
         setIsInland(false);
         setIsLoading(false);
       } catch (err) {

--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -1,9 +1,9 @@
 // src/services/tideDataService.ts
 
-// Fetches 7-day tide data for the selected location and station from backend
-export async function getTideData(locationInput: string, stationId: string) {
+// Fetches 7-day tide data for the selected station from backend
+export async function getTideData(stationId: string, dateIso: string) {
   const response = await fetch(
-    `/tides?locationInput=${encodeURIComponent(locationInput)}&stationId=${encodeURIComponent(stationId)}`
+    `/tides?stationId=${encodeURIComponent(stationId)}&date=${encodeURIComponent(dateIso)}`
   );
   if (!response.ok) throw new Error("Unable to fetch tide data.");
   const data = await response.json();


### PR DESCRIPTION
## Summary
- select nearest NOAA station from `/noaa-stations`
- guard against missing station id
- request tides using the station's id

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685af1f8e340832d87a4e0d70b5d23c2