### PR TITLE
Fix date format for tides fetch

### DIFF
--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -2,8 +2,12 @@
 
 // Fetches 7-day tide data for the selected station from backend
 export async function getTideData(stationId: string, dateIso: string) {
+  const yyyymmdd = dateIso.replace(/-/g, '');
+  if (!stationId || yyyymmdd.length !== 8) {
+    throw new Error('Invalid parameters for tide data request');
+  }
   const response = await fetch(
-    `/tides?stationId=${encodeURIComponent(stationId)}&date=${encodeURIComponent(dateIso)}`
+    `/tides?stationId=${stationId}&date=${yyyymmdd}`
   );
   if (!response.ok) throw new Error("Unable to fetch tide data.");
   const data = await response.json();


### PR DESCRIPTION
## Summary
- convert ISO date to `yyyymmdd` before calling `/tides`
- validate that both `stationId` and `yyyymmdd` are sane

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685bd3a261b8832da4aacea3ef5288ab