### PR TITLE
Handle new tide predictions format

### DIFF
--- a/src/services/tideDataService.ts
+++ b/src/services/tideDataService.ts
@@ -1,17 +1,35 @@
 // src/services/tideDataService.ts
 
 // Fetches 7-day tide data for the selected station from backend
-export async function getTideData(stationId: string, dateIso: string) {
+export interface Prediction {
+  timeIso: string;   // ISO string, local time
+  valueFt: number;   // feet (already in response)
+  kind: 'H' | 'L';   // NOAA's type field
+}
+
+export async function getTideData(
+  stationId: string,
+  dateIso: string
+): Promise<Prediction[]> {
   const yyyymmdd = dateIso.replace(/-/g, '');
   if (!stationId || yyyymmdd.length !== 8) {
     throw new Error('Invalid parameters for tide data request');
   }
+
   const response = await fetch(
     `/tides?stationId=${stationId}&date=${yyyymmdd}`
   );
-  if (!response.ok) throw new Error("Unable to fetch tide data.");
+
+  if (!response.ok) throw new Error('Unable to fetch tide data.');
+
   const data = await response.json();
-  return data;
+  const predictions = Array.isArray(data?.predictions) ? data.predictions : [];
+
+  return predictions.map((p: { t: string; v: string; type: 'H' | 'L' }) => ({
+    timeIso: `${p.t.replace(' ', 'T')}:00`,
+    valueFt: parseFloat(p.v),
+    kind: p.type,
+  }));
 }
 
 // If you need to get station options in this file:


### PR DESCRIPTION
## Summary
- parse predictions from `/tides` proxy in `tideDataService`
- update `useTideData` hook to map predictions to tide points for the UI

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c18c9b9a0832d9a19491a4737ba68