### PR TITLE
Fix undefined tide data in WeeklyForecast

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import MoonPhase from '@/components/MoonPhase';
 import TideChart from '@/components/TideChart';
 import WeeklyForecast from '@/components/WeeklyForecast';
-import { TidePoint, TideForecast } from '@/services/noaaService';
+import { TidePoint, TideForecast } from '@/services/tide/types';
 import { LocationData } from '@/types/locationTypes';
 
 interface MainContentProps {

--- a/src/components/fishing/CalendarCard.tsx
+++ b/src/components/fishing/CalendarCard.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Calendar } from '@/components/ui/calendar';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { TideForecast } from '@/services/noaaService';
+import { TideForecast } from '@/services/tide/types';
 import { isDateFullMoon, isDateNewMoon, getFullMoonName } from '@/utils/lunarUtils';
 import { getSolarEvents } from '@/utils/solarUtils';
 

--- a/src/pages/FishingCalendar.tsx
+++ b/src/pages/FishingCalendar.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import StarsBackdrop from '@/components/StarsBackdrop';
 import { safeLocalStorage } from '@/utils/localStorage';
 import { useTideData } from '@/hooks/useTideData';
-import { TideForecast, TidePoint } from '@/services/noaaService';
+import { TideForecast, TidePoint } from '@/services/tide/types';
 import { calculateSolarTimes } from '@/utils/solarUtils';
 import FishingCalendarHeader from '@/components/fishing/FishingCalendarHeader';
 import CalendarCard from '@/components/fishing/CalendarCard';


### PR DESCRIPTION
## Summary
- include moon phase util when building weekly forecast
- transform tide predictions into full DayForecast objects
- update imports to use TideForecast type from tide service

## Testing
- `npm run lint` *(fails: Unexpected any, require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_685d9efc7308832dad1ba7e23b393b5e