### PR TITLE
Fix NOAA tide proxy to return high/low events

### DIFF
--- a/moontide-proxy/tides.ts
+++ b/moontide-proxy/tides.ts
@@ -46,6 +46,8 @@ router.get('/tides', async (req, res) => {
     format:     'json',
     datum:      'MLLW',
     time_zone:  'lst_ldt',
+    // Return only high/low events so callers get two cycles per day
+    interval:   'hilo',
     units:      'english',
     station:    stationId,
     begin_date: yyyymmdd(start),


### PR DESCRIPTION
## Summary
- use `interval=hilo` when requesting tide predictions to ensure the API returns two cycles per day

## Testing
- `npm run lint` *(fails: Unexpected any issues and require() import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685da26505c0832da28c58e299bdbac0