### PR TITLE
Show two low-high tide cycles per day

### DIFF
--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -7,13 +7,17 @@ import { Info } from "lucide-react";
 import { getFullMoonName, isFullMoon, getMoonEmoji } from '@/utils/lunarUtils';
 import { formatApiDate } from '@/utils/dateTimeUtils';
 
+type TideCycle = {
+  low: { time: string; height: number };
+  high: { time: string; height: number };
+};
+
 type DayForecast = {
   date: string;
   day: string;
   moonPhase: string;
   illumination: number;
-  highTide: { time: string; height: number; };
-  lowTide: { time: string; height: number; };
+  cycles: TideCycle[];
 };
 
 type WeeklyForecastProps = {
@@ -136,18 +140,17 @@ const WeeklyForecast = ({ forecast, isLoading = false, className }: WeeklyForeca
                     </div>
                   </div>
                   
-                  {/* Tide Info - Always display exactly one high tide and one low tide per day */}
+                  {/* Tide Info - display two low-high cycles per day */}
                   <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <p className="text-xs text-muted-foreground">High Tide</p>
-                      <p className="text-sm">{day.highTide.time}</p>
-                      <p className="text-xs text-moon-blue">{day.highTide.height.toFixed(2)}m</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">Low Tide</p>
-                      <p className="text-sm">{day.lowTide.time}</p>
-                      <p className="text-xs text-moon-blue">{day.lowTide.height.toFixed(2)}m</p>
-                    </div>
+                    {day.cycles.map((cycle, idx) => (
+                      <div key={idx}>
+                        <p className="text-xs text-muted-foreground">Cycle {idx + 1}</p>
+                        <p className="text-sm">Low: {cycle.low.time}</p>
+                        <p className="text-xs text-moon-blue mb-1">{cycle.low.height.toFixed(2)}m</p>
+                        <p className="text-sm">High: {cycle.high.time}</p>
+                        <p className="text-xs text-moon-blue">{cycle.high.height.toFixed(2)}m</p>
+                      </div>
+                    ))}
                   </div>
                 </div>
               )

--- a/src/services/tide/types.ts
+++ b/src/services/tide/types.ts
@@ -26,11 +26,15 @@ export type TidePoint = {
   isHighTide: boolean | null; // null for continuous points, true/false for hilo
 };
 
+export type TideCycle = {
+  low: { time: string; height: number };
+  high: { time: string; height: number };
+};
+
 export type TideForecast = {
   date: string;
   day: string;
   moonPhase: string;
   illumination: number;
-  highTide: { time: string; height: number; };
-  lowTide: { time: string; height: number; };
+  cycles: TideCycle[];
 };


### PR DESCRIPTION
## Summary
- expose TideCycle array in TideForecast type
- compute two low-high cycles per day in `useTideData`
- display two tide cycles per day in `WeeklyForecast`

## Testing
- `npm run lint` *(fails: unexpected any and other eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685da5add8b0832da952566551a296b0