### PR TITLE
Fix tide cycle calculation

### DIFF
--- a/src/components/MoonData.tsx
+++ b/src/components/MoonData.tsx
@@ -23,7 +23,7 @@ const getNextPhaseInfo = (currentPhase: string, currentDate: Date) => {
   
   // Calculate actual days to next phase by checking each upcoming day
   let daysToNext = 1;
-  let checkDate = new Date(currentDate);
+  const checkDate = new Date(currentDate);
   
   // Check up to 30 days ahead to find the next phase change
   for (let i = 1; i <= 30; i++) {

--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -11,13 +11,9 @@ import {
   ReferenceLine
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Loader2, Waves, MapPin } from "lucide-react";
+import { Loader2, MapPin } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-type TidePoint = {
-  time: string;
-  height: number; // already in feet
-};
+import { TidePoint } from '@/services/tide/types';
 
 type TideChartProps = {
   data: TidePoint[];
@@ -27,24 +23,6 @@ type TideChartProps = {
   className?: string;
 };
 
-const detectTidePeaks = (points: TidePoint[], type: "high" | "low") => {
-  const peaks: TidePoint[] = [];
-
-  for (let i = 1; i < points.length - 1; i++) {
-    const prev = points[i - 1].height;
-    const curr = points[i].height;
-    const next = points[i + 1].height;
-
-    if (
-      (type === "high" && curr > prev && curr > next) ||
-      (type === "low" && curr < prev && curr < next)
-    ) {
-      peaks.push(points[i]);
-    }
-  }
-
-  return peaks.slice(0, 2).sort((a, b) => a.time.localeCompare(b.time));
-};
 
 const formatTimeToAMPM = (timeString: string) => {
   const date = new Date(timeString);
@@ -68,8 +46,9 @@ const TideChart = ({
     typeof point.time === "string" && point.time.slice(0, 10) === today
   );
 
-  const highTides = detectTidePeaks(todayData, "high");
-  const lowTides = detectTidePeaks(todayData, "low");
+  // We already receive only high/low events, so just separate them
+  const highTides = todayData.filter(tp => tp.isHighTide).slice(0, 2);
+  const lowTides = todayData.filter(tp => tp.isHighTide === false).slice(0, 2);
 
   const currentTimeIndex = currentTime
     ? todayData.findIndex(p => p.time === currentTime)


### PR DESCRIPTION
## Summary
- generate tide cycles across day boundaries so each day has two cycles
- show correct high/low tides in TideChart
- pull daily tide info from weekly forecast
- lint fix in MoonData

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dac4c7e08832db607247b262ad346