### PR TITLE
Update tide cycle display in weekly forecast

### DIFF
--- a/moontide-proxy/tides.ts
+++ b/moontide-proxy/tides.ts
@@ -37,7 +37,7 @@ router.get('/tides', async (req, res) => {
     return res.status(400).json({ error: 'Invalid date format (expect yyyymmdd)' });
   }
   const end = new Date(start);
-  end.setDate(start.getDate() + 6);      // 7-day window
+  end.setDate(start.getDate() + 7);      // 8-day window to capture cross-midnight cycles
 
   /* ---- build NOAA API call --------------------------------------- */
   const params = new URLSearchParams({

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -51,6 +51,15 @@ const WeeklyForecast = ({ forecast, isLoading = false, className }: WeeklyForeca
     }
   };
 
+  const formatTimeToAMPM = (timeString: string) => {
+    const date = new Date(timeString);
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
   const renderSkeletonForecast = () => {
     return Array(7).fill(0).map((_, index) => (
       <div 
@@ -143,12 +152,11 @@ const WeeklyForecast = ({ forecast, isLoading = false, className }: WeeklyForeca
                   {/* Tide Info - display two low-high cycles per day */}
                   <div className="grid grid-cols-2 gap-3">
                     {day.cycles.map((cycle, idx) => (
-                      <div key={idx}>
-                        <p className="text-xs text-muted-foreground">Cycle {idx + 1}</p>
-                        <p className="text-sm">Low: {cycle.low.time}</p>
-                        <p className="text-xs text-moon-blue mb-1">{cycle.low.height.toFixed(2)}m</p>
-                        <p className="text-sm">High: {cycle.high.time}</p>
-                        <p className="text-xs text-moon-blue">{cycle.high.height.toFixed(2)}m</p>
+                      <div key={idx} className="text-sm">
+                        <p className="text-xs text-muted-foreground mb-1">Cycle {idx + 1}</p>
+                        <p>
+                          Low {formatTimeToAMPM(cycle.low.time)} - High {formatTimeToAMPM(cycle.high.time)}
+                        </p>
                       </div>
                     ))}
                   </div>

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -125,6 +125,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
 
         const forecast: TideForecast[] = Object.keys(cyclesByDate)
           .sort()
+          .slice(0, 7)
           .map((date) => {
             const dayObj = new Date(`${date}T00:00:00`);
             const day = dayObj.toLocaleDateString('en-US', { weekday: 'short' });


### PR DESCRIPTION
## Summary
- fetch an extra day of tide data for boundary cycles
- limit forecast to the first seven days only
- simplify weekly forecast tide cycle display and show times in 12‑hour format

## Testing
- `npm run lint` *(fails: Unexpected any, require-imports, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685db2857b8c832d8c161b9ae3bf3548