### PR TITLE
Improve tide chart continuity

### DIFF
--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -46,23 +46,18 @@ const TideChart = ({
   const endOfDay = new Date(startOfDay);
   endOfDay.setDate(endOfDay.getDate() + 1);
 
-  const rawTodayData = (data || []).filter((point) => {
-    const ts = new Date(point.time).getTime();
-    return ts >= startOfDay.getTime() && ts < endOfDay.getTime();
-  });
-
-  const chartData = rawTodayData
+  const allPoints = (data || [])
     .map((tp) => ({ ...tp, ts: new Date(tp.time).getTime() }))
     .sort((a, b) => a.ts - b.ts);
 
-  if (chartData.length > 0) {
-    if (chartData[0].ts > startOfDay.getTime()) {
-      chartData.unshift({ ...chartData[0], ts: startOfDay.getTime(), time: new Date(startOfDay).toISOString() });
-    }
-    if (chartData[chartData.length - 1].ts < endOfDay.getTime()) {
-      chartData.push({ ...chartData[chartData.length - 1], ts: endOfDay.getTime(), time: new Date(endOfDay).toISOString() });
-    }
-  }
+  const rawTodayData = allPoints.filter(p => p.ts >= startOfDay.getTime() && p.ts < endOfDay.getTime());
+
+  const prevPoint = allPoints.filter(p => p.ts < startOfDay.getTime()).slice(-1)[0];
+  const nextPoint = allPoints.find(p => p.ts >= endOfDay.getTime());
+
+  const chartData = [...rawTodayData];
+  if (prevPoint) chartData.unshift(prevPoint);
+  if (nextPoint) chartData.push(nextPoint);
 
   // We already receive only high/low events, so just separate them
   const highTides = rawTodayData.filter(tp => tp.isHighTide).slice(0, 2);

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -83,7 +83,9 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
           setIsLoading(false);
           return;
         }
-        const dateIso = new Date().toISOString().split('T')[0];
+        const startDate = new Date();
+        startDate.setDate(startDate.getDate() - 1); // include prior day for smoother charts
+        const dateIso = startDate.toISOString().split('T')[0];
         const predictions: Prediction[] = await getTideData(
           station.id,
           dateIso,
@@ -123,8 +125,10 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
           }
         });
 
+        const todayStr = getCurrentDateString();
         const forecast: TideForecast[] = Object.keys(cyclesByDate)
           .sort()
+          .filter(d => d >= todayStr)
           .slice(0, 7)
           .map((date) => {
             const dayObj = new Date(`${date}T00:00:00`);


### PR DESCRIPTION
## Summary
- include previous day's tide data when fetching predictions
- skip past days when generating weekly forecast
- extend tide chart with adjacent points so the graph doesn't start and end flat

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_685db9653114832da499a3c891dab44c