### PR TITLE
Add continuous tide chart

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -10,6 +10,7 @@ interface MainContentProps {
   error: string | null;
   isLoading: boolean;
   tideData: TidePoint[];
+  tideEvents: TidePoint[];
   weeklyForecast: TideForecast[];
   currentDate: string;
   currentTime: string;
@@ -18,12 +19,13 @@ interface MainContentProps {
   onGetStarted?: (location?: LocationData) => void;
 }
 
-export default function MainContent({ 
-  error, 
-  isLoading, 
-  tideData, 
-  weeklyForecast, 
-  currentDate, 
+export default function MainContent({
+  error,
+  isLoading,
+  tideData,
+  tideEvents,
+  weeklyForecast,
+  currentDate,
   currentTime,
   currentLocation,
   stationName,
@@ -55,7 +57,8 @@ export default function MainContent({
         />
 
         <TideChart
-          data={tideData}
+          curve={tideData}
+          events={tideEvents}
           date={currentDate || moonPhaseData.date}
           currentTime={currentTime}
           isLoading={isLoading}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,6 +29,7 @@ const Index = () => {
     isLoading,
     error,
     tideData,
+    tideEvents,
     weeklyForecast,
     currentDate,
     currentTime,
@@ -60,6 +61,7 @@ const Index = () => {
         error={error}
         isLoading={isLoading}
         tideData={tideData}
+        tideEvents={tideEvents}
         weeklyForecast={weeklyForecast}
         currentDate={currentDate}
         currentTime={currentTime}

--- a/src/services/tide/tideService.ts
+++ b/src/services/tide/tideService.ts
@@ -134,3 +134,21 @@ export async function fetchDailyTides(
 }
 
 /**
+ * Fetch continuous six-minute tide height data for a date range.
+ */
+export async function fetchSixMinuteRange(
+  station: NoaaStation,
+  start: Date,
+  end: Date,
+  units: 'english' | 'metric' = 'english'
+) {
+  const beginDate = dateToYYYYMMDD(start);
+  const endDate = dateToYYYYMMDD(end);
+  return fetchPredictions({
+    station: station.id,
+    beginDate,
+    endDate,
+    interval: '6',
+    units,
+  }, station);
+}


### PR DESCRIPTION
## Summary
- show tide data line from continuous 6-minute predictions
- add tide event list for high and low tides
- display graph with x-axis from midnight to midnight

## Testing
- `npm run lint` *(fails: 29 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685dbfb52f98832d98521660f4b04716