### PR TITLE
Fix tide chart display after graph update

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -5,6 +5,7 @@ import TideChart from '@/components/TideChart';
 import WeeklyForecast from '@/components/WeeklyForecast';
 import { TidePoint, TideForecast } from '@/services/tide/types';
 import { LocationData } from '@/types/locationTypes';
+import { formatApiDate } from '@/utils/dateTimeUtils';
 
 interface MainContentProps {
   error: string | null;
@@ -36,7 +37,7 @@ export default function MainContent({
     illumination: weeklyForecast.length > 0 ? weeklyForecast[0].illumination : 35,
     moonrise: "18:42",
     moonset: "07:15",
-    date: currentDate || "May 21, 2025"
+    date: formatApiDate(currentDate)
   };
 
   console.log('MainContent onGetStarted function:', onGetStarted);
@@ -59,7 +60,7 @@ export default function MainContent({
         <TideChart
           curve={tideData}
           events={tideEvents}
-          date={currentDate || moonPhaseData.date}
+          date={currentDate}
           currentTime={currentTime}
           isLoading={isLoading}
         />

--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -43,6 +43,10 @@ const TideChart = ({
   className
 }: TideChartProps) => {
   const today = new Date(date + 'T00:00:00');
+  if (isNaN(today.getTime())) {
+    const fallback = new Date(date);
+    if (!isNaN(fallback.getTime())) today.setTime(fallback.getTime());
+  }
   const startOfDay = new Date(today);
   startOfDay.setHours(0, 0, 0, 0);
   const endOfDay = new Date(startOfDay);

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -2,7 +2,10 @@ import { useState, useEffect } from 'react';
 import { getTideData, Prediction } from '@/services/tideDataService';
 import { getStationsForUserLocation } from '@/services/noaaService';
 import { fetchSixMinuteRange } from '@/services/tide/tideService';
-import { getCurrentDateString, getCurrentTimeString } from '@/utils/dateTimeUtils';
+import {
+  getCurrentIsoDateString,
+  getCurrentTimeString,
+} from '@/utils/dateTimeUtils';
 import { TidePoint, TideForecast, TideCycle } from '@/services/tide/types';
 import { calculateMoonPhase } from '@/utils/lunarUtils';
 
@@ -42,13 +45,13 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
   const [tideData, setTideData] = useState<TidePoint[]>([]);
   const [tideEvents, setTideEvents] = useState<TidePoint[]>([]);
   const [weeklyForecast, setWeeklyForecast] = useState<TideForecast[]>([]);
-  const [currentDate, setCurrentDate] = useState<string>(getCurrentDateString());
+  const [currentDate, setCurrentDate] = useState<string>(getCurrentIsoDateString());
   const [currentTime, setCurrentTime] = useState<string>(getCurrentTimeString());
   const [stationName, setStationName] = useState<string | null>(null);
   const [isInland, setIsInland] = useState<boolean>(false);
 
   useEffect(() => {
-    setCurrentDate(getCurrentDateString());
+    setCurrentDate(getCurrentIsoDateString());
     setCurrentTime(getCurrentTimeString());
 
     if (!location) {
@@ -153,7 +156,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
           }
         });
 
-        const todayStr = getCurrentDateString();
+        const todayStr = getCurrentIsoDateString();
         const forecast: TideForecast[] = Object.keys(cyclesByDate)
           .sort()
           .filter(d => d >= todayStr)
@@ -175,7 +178,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
         setTideData(detailedPoints);
         setTideEvents(tidePoints);
         setWeeklyForecast(forecast);
-        setCurrentDate(getCurrentDateString());
+        setCurrentDate(getCurrentIsoDateString());
         setCurrentTime(getCurrentTimeString());
         setStationName(station.name || location.name || null);
         setIsInland(false);

--- a/src/utils/dateTimeUtils.ts
+++ b/src/utils/dateTimeUtils.ts
@@ -3,11 +3,15 @@
 
 export const getCurrentDateString = (): string => {
   const now = new Date();
-  return now.toLocaleDateString('en-US', { 
-    year: 'numeric', 
-    month: 'long', 
-    day: 'numeric' 
+  return now.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
   });
+};
+
+export const getCurrentIsoDateString = (): string => {
+  return new Date().toISOString().split('T')[0];
 };
 
 export const getCurrentTimeString = (): string => {


### PR DESCRIPTION
## Summary
- use ISO date format for internal tide calculations
- update MainContent to format display date but keep ISO for charts
- harden date parsing in TideChart to handle formatted strings

## Testing
- `npm run lint` *(fails: no-explicit-any and other issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685dc431720c832db1ec0050b78fb7b1