### PR TITLE
Add Newport fallback station mapping

### DIFF
--- a/src/services/tide/stationMap.ts
+++ b/src/services/tide/stationMap.ts
@@ -7,7 +7,12 @@
  * for station lookups. Real station data is fetched from realStationService.ts
  */
 
-// Empty mapping - we now use real NOAA data
-export const STATION_BY_ZIP: Record<string, { id: string; name: string }> = {};
+// Basic ZIP -> station mapping used as a fallback when live
+// station lookups fail. Only contains a few well known ZIP
+// codes and their associated NOAA station ids.
+export const STATION_BY_ZIP: Record<string, { id: string; name: string }> = {
+  // Newport, Rhode Island
+  '02840': { id: '8452660', name: 'Newport, RI' },
+};
 
 console.log('🗺️ Station mapping is now using real NOAA data instead of hardcoded values');


### PR DESCRIPTION
## Summary
- define a simple fallback in `stationMap.ts` for Newport, RI

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ddbcbc7fc832d9a89d3b11b5ccefd