### PR TITLE
Display NOAA station ID in location info

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -6,10 +6,11 @@ import { SavedLocation } from './LocationSelector';
 interface LocationDisplayProps {
   currentLocation: SavedLocation & { id: string; country: string } | null;
   stationName: string | null;
+  stationId?: string | null;
   hasError?: boolean; // Add this prop to detect tide data errors
 }
 
-export default function LocationDisplay({ currentLocation, stationName, hasError }: LocationDisplayProps) {
+export default function LocationDisplay({ currentLocation, stationName, stationId, hasError }: LocationDisplayProps) {
   const formatLocationDisplay = () => {
     if (!currentLocation) return "Select a location";
     
@@ -50,7 +51,7 @@ export default function LocationDisplay({ currentLocation, stationName, hasError
       {/* Station name under ZIP - show helpful message if there's an error even with a station */}
       <div className="text-xs text-muted-foreground pl-5">
         {stationName && !hasError ? (
-          <>Tide data from NOAA station: <span className="font-medium">{stationName}</span></>
+          <>Tide data from NOAA station: <span className="font-medium">{stationName}</span>{stationId ? ` (ID: ${stationId})` : ''}</>
         ) : (
           <>No tide data available - this may be a non-coastal area. Try a coastal ZIP code for tide information.</>
         )}

--- a/src/components/LocationInfo.tsx
+++ b/src/components/LocationInfo.tsx
@@ -5,10 +5,11 @@ import { MapPin } from 'lucide-react';
 type LocationInfoProps = {
   currentLocation: any;
   stationName: string | null;
+  stationId: string | null;
   error: string | null;
 };
 
-const LocationInfo = ({ currentLocation, stationName, error }: LocationInfoProps) => {
+const LocationInfo = ({ currentLocation, stationName, stationId, error }: LocationInfoProps) => {
   const formatLocationDisplay = () => {
     if (!currentLocation) return "Select a location";
     
@@ -30,7 +31,7 @@ const LocationInfo = ({ currentLocation, stationName, error }: LocationInfoProps
         </div>
         <div className="text-muted-foreground mt-1">
           {stationName && !error ? (
-            <>NOAA station: <span className="font-medium">{stationName}</span></>
+            <>NOAA station: <span className="font-medium">{stationName}</span>{stationId ? ` (ID: ${stationId})` : ''}</>
           ) : (
             <>No tide data available - try a coastal ZIP code if tidal information is needed</>
           )}

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -17,6 +17,7 @@ interface MainContentProps {
   currentTime: string;
   currentLocation: any;
   stationName: string | null;
+  stationId: string | null;
   onGetStarted?: (location?: LocationData) => void;
 }
 
@@ -30,6 +31,7 @@ export default function MainContent({
   currentTime,
   currentLocation,
   stationName,
+  stationId,
   onGetStarted
 }: MainContentProps) {
   const moonPhaseData = {
@@ -53,6 +55,7 @@ export default function MainContent({
           date={moonPhaseData.date}
           currentLocation={currentLocation}
           stationName={stationName}
+          stationId={stationId}
           error={error}
           onGetStarted={onGetStarted}
         />

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -20,6 +20,7 @@ type MoonPhaseProps = {
   className?: string;
   currentLocation?: any;
   stationName?: string | null;
+  stationId?: string | null;
   error?: string | null;
   onGetStarted?: (location?: LocationData) => void;
 }
@@ -33,6 +34,7 @@ const MoonPhase = ({
   className,
   currentLocation,
   stationName,
+  stationId,
   error,
   onGetStarted
 }: MoonPhaseProps) => {
@@ -92,6 +94,7 @@ const MoonPhase = ({
               <LocationInfo
                 currentLocation={currentLocation}
                 stationName={stationName}
+                stationId={stationId}
                 error={error}
               />
             ) : (

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -36,6 +36,7 @@ type UseTideDataReturn = {
   currentDate: string;
   currentTime: string;
   stationName: string | null;
+  stationId: string | null;
   isInland: boolean;
 };
 
@@ -48,6 +49,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
   const [currentDate, setCurrentDate] = useState<string>(getCurrentIsoDateString());
   const [currentTime, setCurrentTime] = useState<string>(getCurrentTimeString());
   const [stationName, setStationName] = useState<string | null>(null);
+  const [stationId, setStationId] = useState<string | null>(null);
   const [isInland, setIsInland] = useState<boolean>(false);
 
   useEffect(() => {
@@ -61,6 +63,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
       setTideEvents([]);
       setWeeklyForecast([]);
       setStationName(null);
+      setStationId(null);
       setIsInland(false);
       return;
     }
@@ -80,6 +83,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
           setTideEvents([]);
           setWeeklyForecast([]);
           setStationName(null);
+          setStationId(null);
           setIsLoading(false);
           return;
         }
@@ -88,6 +92,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
         const station = stations[0];
         if (!station?.id) {
           console.warn('No station ID available for location', location);
+          setStationId(null);
           setIsLoading(false);
           return;
         }
@@ -181,6 +186,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
         setCurrentDate(getCurrentIsoDateString());
         setCurrentTime(getCurrentTimeString());
         setStationName(station.name || location.name || null);
+        setStationId(station.id);
         setIsInland(false);
         setIsLoading(false);
       } catch (err) {
@@ -190,6 +196,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
         setTideEvents([]);
         setWeeklyForecast([]);
         setStationName(null);
+        setStationId(null);
         setIsInland(false);
       }
     };
@@ -206,6 +213,7 @@ export const useTideData = ({ location }: UseTideDataParams): UseTideDataReturn 
     currentDate,
     currentTime,
     stationName,
+    stationId,
     isInland,
   };
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -33,7 +33,8 @@ const Index = () => {
     weeklyForecast,
     currentDate,
     currentTime,
-    stationName
+    stationName,
+    stationId
   } = useTideData({ location: currentLocation });
 
   console.log('📊 useTideData results:', {
@@ -67,6 +68,7 @@ const Index = () => {
         currentTime={currentTime}
         currentLocation={currentLocation}
         stationName={stationName}
+        stationId={stationId}
         onGetStarted={handleGetStarted}
       />
     </div>


### PR DESCRIPTION
## Summary
- show NOAA station IDs in the location display
- plumb stationId through `useTideData` hook and related components

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685e6be7657c832d9500c20ba8468e20