### PR TITLE
Fix invalid hook errors via React alias

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,8 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      react: path.resolve(__dirname, "node_modules/react"),
+      "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
     },
   },
 }));


### PR DESCRIPTION
## Summary
- alias React and ReactDOM in vite config

## Testing
- `npm run lint` *(fails: unexpected any in various files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e766b8288832dadb909646e087d5b