### PR TITLE
Show station picker on location search

### DIFF
--- a/src/components/LocationDisplay.tsx
+++ b/src/components/LocationDisplay.tsx
@@ -50,10 +50,12 @@ export default function LocationDisplay({ currentLocation, stationName, stationI
       </div>
       {/* Station name under ZIP - show helpful message if there's an error even with a station */}
       <div className="text-xs text-muted-foreground pl-5">
-        {stationName && !hasError ? (
+        {hasError ? (
+          <>No tide data available for the selected station.</>
+        ) : stationName ? (
           <>Tide data from NOAA station: <span className="font-medium">{stationName}</span>{stationId ? ` (ID: ${stationId})` : ''}</>
         ) : (
-          <>No tide data available - this may be a non-coastal area. Try a coastal ZIP code for tide information.</>
+          <>Select a tide station to view data.</>
         )}
       </div>
     </div>

--- a/src/components/LocationInfo.tsx
+++ b/src/components/LocationInfo.tsx
@@ -1,9 +1,10 @@
 
 import React from 'react';
 import { MapPin } from 'lucide-react';
+import { SavedLocation } from './LocationSelector';
 
 type LocationInfoProps = {
-  currentLocation: any;
+  currentLocation: (SavedLocation & { id: string; country: string }) | null;
   stationName: string | null;
   stationId: string | null;
   error: string | null;
@@ -30,10 +31,12 @@ const LocationInfo = ({ currentLocation, stationName, stationId, error }: Locati
           {formatLocationDisplay()}
         </div>
         <div className="text-muted-foreground mt-1">
-          {stationName && !error ? (
+          {error ? (
+            <>No tide data available for the selected station.</>
+          ) : stationName ? (
             <>NOAA station: <span className="font-medium">{stationName}</span>{stationId ? ` (ID: ${stationId})` : ''}</>
           ) : (
-            <>No tide data available - try a coastal ZIP code if tidal information is needed</>
+            <>Select a tide station to view data.</>
           )}
         </div>
       </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -35,21 +35,21 @@ const Index = () => {
   console.log('🌊 Current location for useTideData:', currentLocation);
 
   useEffect(() => {
-    if (!currentLocation) return;
+    if (!currentLocation) {
+      setAvailableStations([]);
+      setSelectedStation(null);
+      setShowStationPicker(false);
+      return;
+    }
+
     const input = currentLocation.zipCode || currentLocation.cityState || currentLocation.name;
+    setSelectedStation(null);
     getStationsForLocationInput(input)
       .then((stations) => {
         if (!stations || stations.length === 0) {
           setAvailableStations([]);
-          setSelectedStation(null);
           setShowStationPicker(false);
-          if (currentLocation.zipCode) {
-            toast.error('No NOAA stations found for this ZIP code.');
-          }
-        } else if (stations.length === 1) {
-          setAvailableStations([]);
-          setSelectedStation(stations[0]);
-          setShowStationPicker(false);
+          toast.error('No NOAA stations found for this location.');
         } else {
           setAvailableStations(stations);
           setShowStationPicker(true);
@@ -59,7 +59,7 @@ const Index = () => {
         setAvailableStations([]);
         setShowStationPicker(false);
       });
-  }, [currentLocation]);
+  }, [currentLocation, setSelectedStation]);
 
   const {
     isLoading,


### PR DESCRIPTION
## Summary
- prompt for NOAA station selection whenever a location is chosen
- use the chosen station exclusively when loading tide data
- show helpful messages when no station is selected

## Testing
- `npx eslint src/hooks/useTideData.tsx src/components/LocationDisplay.tsx src/components/LocationInfo.tsx src/pages/Index.tsx`
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ea0b7819c832d888de81315758fbd