### PR TITLE
Add logging for station selection

### DIFF
--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -23,6 +23,7 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose }: S
   const handleConfirm = () => {
     const station = stations.find((s) => s.id === selectedId);
     if (station) {
+      console.log('📍 StationPicker handleConfirm:', { selectedId, station });
       onSelect(station);
     }
     onClose();

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -87,6 +87,10 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
         const startDate = new Date();
         startDate.setDate(startDate.getDate() - 1); // include prior day for smoother charts
         const dateIso = startDate.toISOString().split('T')[0];
+        console.log('🌐 useTideData getTideData:', {
+          stationId: chosen.id,
+          date: dateIso
+        });
         const predictions: Prediction[] = await getTideData(
           chosen.id,
           dateIso,
@@ -98,6 +102,11 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
         rangeStart.setDate(rangeStart.getDate() - 1);
         const rangeEnd = new Date();
         rangeEnd.setDate(rangeEnd.getDate() + 1);
+        console.log('🌐 useTideData fetchSixMinuteRange:', {
+          stationId: chosen.id,
+          rangeStart,
+          rangeEnd
+        });
         const detailedRaw = await fetchSixMinuteRange(
           {
             id: chosen.id,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,6 +32,11 @@ const Index = () => {
   const [availableStations, setAvailableStations] = useState<Station[]>([]);
   const [showStationPicker, setShowStationPicker] = useState(false);
 
+  const handleStationSelect = (st: Station) => {
+    console.log('🎯 Index onSelect station:', st);
+    setSelectedStation(st);
+  };
+
   console.log('🌊 Current location for useTideData:', currentLocation);
 
   useEffect(() => {
@@ -111,7 +116,7 @@ const Index = () => {
       <StationPicker
         isOpen={showStationPicker}
         stations={availableStations}
-        onSelect={(st) => setSelectedStation(st)}
+        onSelect={handleStationSelect}
         onClose={() => setShowStationPicker(false)}
       />
     </div>

--- a/src/services/tide/tideService.ts
+++ b/src/services/tide/tideService.ts
@@ -59,7 +59,10 @@ function getCacheKey(p: PredictionParams): string {
 async function fetchPredictions(p: PredictionParams, station: NoaaStation) {
   const noaaUrl = buildQuery(p);
   const cacheKey = getCacheKey(p);
-  console.log('🌐 Fetching live tide data from NOAA...');
+  console.log('🌐 Fetching live tide data from NOAA...', {
+    stationId: station.id,
+    url: noaaUrl
+  });
   
   // Try direct NOAA API first
   try {


### PR DESCRIPTION
## Summary
- trace selected station in StationPicker
- log selected station in Index before updating state
- show selected station ID when fetching tide data
- log NOAA URL used for tide fetches

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_685edd3f38c4832d87f2ca3fa14b1a81