### PR TITLE
Fix station picker effect dependencies

### DIFF
--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -15,10 +15,10 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose }: S
   const [selectedId, setSelectedId] = useState<string>('');
 
   useEffect(() => {
-    if (stations.length > 0) {
+    if (selectedId === '' && stations.length > 0) {
       setSelectedId(stations[0].id);
     }
-  }, [stations]);
+  }, [selectedId, stations]);
 
   const handleConfirm = () => {
     const station = stations.find((s) => s.id === selectedId);


### PR DESCRIPTION
## Summary
- add guard around selectedId initializer in `StationPicker`

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685fe1bd6738832d90a8698dd701aadf