### PR TITLE
Fix infinite update loops

### DIFF
--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -59,25 +59,28 @@ export const useLocationState = () => {
     }
   });
 
-  const setCurrentLocationWithLogging = (location: SavedLocation & { id: string; country: string } | null) => {
-    console.log('🔄 useLocationState: setCurrentLocation called with:', location);
-    setCurrentLocation(location);
-    
-    if (location) {
-      console.log('✅ useLocationState: User now has a location');
-    } else {
-      console.log('🎯 useLocationState: User has no location');
-    }
-  };
+  const setCurrentLocationWithLogging = React.useCallback(
+    (location: (SavedLocation & { id: string; country: string }) | null) => {
+      console.log('🔄 useLocationState: setCurrentLocation called with:', location);
+      setCurrentLocation(location);
 
-  const setSelectedStationWithPersist = (station: Station | null) => {
+      if (location) {
+        console.log('✅ useLocationState: User now has a location');
+      } else {
+        console.log('🎯 useLocationState: User has no location');
+      }
+    },
+    []
+  );
+
+  const setSelectedStationWithPersist = React.useCallback((station: Station | null) => {
     setSelectedStation(station);
     try {
       safeLocalStorage.set(CURRENT_STATION_KEY, station);
     } catch (err) {
       console.warn('⚠️ Error saving station selection:', err);
     }
-  };
+  }, []);
 
   useEffect(() => {
     console.log('📝 useLocationState useEffect: Setting document title for location:', currentLocation?.name);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -41,14 +41,14 @@ const Index = () => {
 
   useEffect(() => {
     if (!currentLocation) {
-      setAvailableStations([]);
-      setSelectedStation(null);
-      setShowStationPicker(false);
+      if (availableStations.length !== 0) setAvailableStations([]);
+      if (selectedStation !== null) setSelectedStation(null);
+      if (showStationPicker) setShowStationPicker(false);
       return;
     }
 
     const input = currentLocation.zipCode || currentLocation.cityState || currentLocation.name;
-    setSelectedStation(null);
+    if (selectedStation !== null) setSelectedStation(null);
     getStationsForLocationInput(input)
       .then((stations) => {
         if (!stations || stations.length === 0) {
@@ -64,7 +64,7 @@ const Index = () => {
         setAvailableStations([]);
         setShowStationPicker(false);
       });
-  }, [currentLocation, setSelectedStation]);
+  }, [currentLocation]);
 
   const {
     isLoading,


### PR DESCRIPTION
## Summary
- memoize location setter helpers so their identity is stable
- guard state updates in station fetch effect and clean up dependencies

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ff0261c80832d9b56db1236c439d0