### PR TITLE
Fix tide chart fallback

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -133,6 +133,8 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
           }))
           .sort((a, b) => a.time.localeCompare(b.time));
 
+        const curveData = detailedPoints.length > 0 ? detailedPoints : tidePoints;
+
         // Build tide cycles across the full dataset so pairs can cross midnight
         const cyclesByDate: Record<string, TideCycle[]> = {};
         let pendingLow: TideEvent | null = null;
@@ -177,7 +179,7 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
             } as TideForecast;
           });
 
-        setTideData(detailedPoints);
+        setTideData(curveData);
         setTideEvents(tidePoints);
         setWeeklyForecast(forecast);
         setCurrentDate(getCurrentIsoDateString());


### PR DESCRIPTION
## Summary
- handle case with no high-resolution tide data

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6860710492ac832db04f6cdd1a096a65