### PR TITLE
Improve station lookup UX

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,6 +32,7 @@ const Index = () => {
 
   const [availableStations, setAvailableStations] = useState<Station[]>([]);
   const [showStationPicker, setShowStationPicker] = useState(false);
+  const [isStationLoading, setIsStationLoading] = useState(false);
 
   const handleStationSelect = (st: Station) => {
     console.log('🎯 Index onSelect station:', st);
@@ -50,6 +51,7 @@ const Index = () => {
 
     const input = currentLocation.zipCode || currentLocation.cityState || currentLocation.name;
     if (selectedStation !== null) setSelectedStation(null);
+    setIsStationLoading(true);
     getStationsForLocationInput(input)
       .then((stations) => {
         if (!stations || stations.length === 0) {
@@ -64,6 +66,9 @@ const Index = () => {
       .catch(() => {
         setAvailableStations([]);
         setShowStationPicker(false);
+      })
+      .finally(() => {
+        setIsStationLoading(false);
       });
   }, [currentLocation]);
 
@@ -89,6 +94,7 @@ const Index = () => {
   return (
     <div className="min-h-screen pb-8 relative">
       <StarsBackdrop />
+      <LoadingOverlay show={isStationLoading} message="Finding tide stations..." />
       <LoadingOverlay show={isLoading} message="Fetching tide data..." />
       
       <AppHeader 

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -1,5 +1,9 @@
 // src/services/tide/stationService.ts
 
+import { cacheService } from '../cacheService';
+
+const STATION_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
 export interface Station {
   id: string;
   name: string;
@@ -15,10 +19,19 @@ export interface Station {
 export async function getStationsForLocation(
   userInput: string
 ): Promise<Station[]> {
+  const key = `stations:${userInput.toLowerCase()}`;
+
+  const cached = cacheService.get<Station[]>(key);
+  if (cached) {
+    return cached;
+  }
+
   const response = await fetch(
     `/noaa-stations?locationInput=${encodeURIComponent(userInput)}`
   );
   if (!response.ok) throw new Error("Unable to fetch station list.");
   const data = await response.json();
-  return data.stations || [];
+  const stations = data.stations || [];
+  cacheService.set(key, stations, STATION_CACHE_TTL);
+  return stations;
 }


### PR DESCRIPTION
## Summary
- cache station lookup results
- show loading overlay while resolving station list

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68612a210098832dac5bafe690966ed2