### PR TITLE
Improve station handling

### DIFF
--- a/moontide-proxy/noaaStations.ts
+++ b/moontide-proxy/noaaStations.ts
@@ -200,4 +200,37 @@ router.get('/noaa-stations', async (req, res) => {
   }
 });
 
+// Lookup a station directly by its NOAA ID
+router.get('/noaa-station/:id', async (req, res) => {
+  res.set('Access-Control-Allow-Origin', '*');
+  const id = req.params.id;
+  if (!id) {
+    res.status(400).json({ error: 'Missing station id' });
+    return;
+  }
+
+  try {
+    const url = `https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/${id}.json`;
+    const response = await axios.get(url);
+    const station = response.data?.stations?.[0];
+    if (!station) {
+      res.status(404).json({ error: 'Station not found' });
+      return;
+    }
+
+    const result = {
+      id: String(station.id),
+      name: station.name,
+      latitude: parseFloat(station.lat),
+      longitude: parseFloat(station.lng),
+      state: station.state,
+    };
+
+    res.json({ station: result });
+  } catch (err) {
+    console.error('Station lookup by id error:', err);
+    res.status(500).json({ error: 'Failed to fetch station' });
+  }
+});
+
 export default router;

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -4,25 +4,28 @@ import { Link } from 'react-router-dom';
 import { CloudMoon, Calendar, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import LocationSelector, { SavedLocation } from './LocationSelector';
+import { Station } from '@/services/tide/stationService';
 
 interface AppHeaderProps {
   currentLocation: SavedLocation & { id: string; country: string } | null;
   stationName: string | null;
   onLocationChange: (location: SavedLocation) => void;
+  onStationSelect?: (station: Station) => void;
   onLocationClear?: () => void;
   hasError?: boolean;
   forceShowLocationSelector?: boolean;
   onLocationSelectorClose?: () => void;
 }
 
-export default function AppHeader({ 
-  currentLocation, 
-  stationName, 
+export default function AppHeader({
+  currentLocation,
+  stationName,
   onLocationChange,
+  onStationSelect,
   onLocationClear,
   hasError,
   forceShowLocationSelector,
-  onLocationSelectorClose 
+  onLocationSelectorClose
 }: AppHeaderProps) {
   return (
     <header className="py-4 px-4 sm:px-6 lg:px-8">
@@ -33,6 +36,11 @@ export default function AppHeader({
             <h1 className="text-2xl font-bold bg-gradient-to-r from-moon-primary to-moon-blue bg-clip-text text-transparent">
               MoonTide
             </h1>
+            {stationName && (
+              <span className="ml-2 text-sm text-muted-foreground hidden md:inline">
+                {stationName}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-3">
             <Link to="/fishing-calendar">
@@ -47,8 +55,9 @@ export default function AppHeader({
                 <span className="hidden md:inline">Settings</span>
               </Button>
             </Link>
-            <LocationSelector 
+            <LocationSelector
               onSelect={onLocationChange}
+              onStationSelect={onStationSelect}
               forceOpen={forceShowLocationSelector}
               onClose={onLocationSelectorClose}
             />

--- a/src/components/EnhancedLocationInput.tsx
+++ b/src/components/EnhancedLocationInput.tsx
@@ -7,9 +7,11 @@ import { toast } from 'sonner';
 import { locationStorage } from '@/utils/locationStorage';
 import { LocationData } from '@/types/locationTypes';
 import UnifiedLocationInput from './UnifiedLocationInput';
+import { Station } from '@/services/tide/stationService';
 
 interface EnhancedLocationInputProps {
   onLocationSelect: (location: LocationData) => void;
+  onStationSelect?: (station: Station) => void;
   onLocationClear?: () => void;
   onClose: () => void;
 }
@@ -18,7 +20,7 @@ interface SavedLocationWithNickname extends LocationData {
   nickname?: string;
 }
 
-export default function EnhancedLocationInput({ onLocationSelect, onLocationClear, onClose }: EnhancedLocationInputProps) {
+export default function EnhancedLocationInput({ onLocationSelect, onStationSelect, onLocationClear, onClose }: EnhancedLocationInputProps) {
   const [savedLocations, setSavedLocations] = useState<SavedLocationWithNickname[]>([]);
   const [editingNickname, setEditingNickname] = useState<string | null>(null);
   const [nicknameInput, setNicknameInput] = useState('');
@@ -84,6 +86,7 @@ export default function EnhancedLocationInput({ onLocationSelect, onLocationClea
       {/* Unified Input Section */}
       <UnifiedLocationInput
         onLocationSelect={handleLocationSelect}
+        onStationSelect={onStationSelect}
         onClose={onClose}
         placeholder="02840 or Newport, RI"
       />

--- a/src/components/LocationInputForm.tsx
+++ b/src/components/LocationInputForm.tsx
@@ -117,6 +117,7 @@ export default function LocationInputForm({
           <li>ZIP: <code>02840</code></li>
           <li>City State: <code>Newport RI</code></li>
           <li>Full: <code>Newport RI 02840</code></li>
+          <li>Station ID: <code>8452660</code></li>
         </ul>
       </div>
     </div>

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -7,6 +7,7 @@ import { locationStorage } from '@/utils/locationStorage';
 import { LocationData } from '@/types/locationTypes';
 import EnhancedLocationInput from './EnhancedLocationInput';
 import SavedLocationsList from './SavedLocationsList';
+import { Station } from '@/services/tide/stationService';
 
 // Keep the SavedLocation interface for backward compatibility
 export interface SavedLocation {
@@ -24,11 +25,13 @@ export default function LocationSelector({
   onLocationClear,
   forceOpen,
   onClose,
+  onStationSelect
 }: {
   onSelect: (loc: SavedLocation) => void;
   onLocationClear?: () => void;
   forceOpen?: boolean;
   onClose?: () => void;
+  onStationSelect?: (station: Station) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [showAddNew, setShowAddNew] = useState(false);
@@ -126,6 +129,7 @@ export default function LocationSelector({
             </div>
             <EnhancedLocationInput
               onLocationSelect={handleLocationSelect}
+              onStationSelect={onStationSelect}
               onLocationClear={handleLocationClear}
               onClose={() => setIsOpen(false)}
             />

--- a/src/components/UnifiedLocationInput.tsx
+++ b/src/components/UnifiedLocationInput.tsx
@@ -3,23 +3,27 @@ import React from 'react';
 import { LocationData } from '@/types/locationTypes';
 import { useLocationSearch } from '@/hooks/useLocationSearch';
 import { useGPSLocation } from '@/hooks/useGPSLocation';
+import { Station } from '@/services/tide/stationService';
 import LocationInputForm from './LocationInputForm';
 
 interface UnifiedLocationInputProps {
   onLocationSelect: (location: LocationData) => void;
+  onStationSelect?: (station: Station) => void;
   onClose?: () => void;
   placeholder?: string;
   autoFocus?: boolean;
 }
 
 export default function UnifiedLocationInput({ 
-  onLocationSelect, 
-  onClose, 
+  onLocationSelect,
+  onStationSelect,
+  onClose,
   placeholder = "ZIP, City State, or City State ZIP",
   autoFocus = true
 }: UnifiedLocationInputProps) {
   const { isLoading: searchLoading, handleLocationSearch } = useLocationSearch({
     onLocationSelect,
+    onStationSelect,
     onClose
   });
 

--- a/src/pages/FishingCalendar.tsx
+++ b/src/pages/FishingCalendar.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { format, addDays, addMonths, parse } from 'date-fns';
 import { Card, CardContent } from "@/components/ui/card";
 import StarsBackdrop from '@/components/StarsBackdrop';
-import { safeLocalStorage } from '@/utils/localStorage';
 import { useTideData } from '@/hooks/useTideData';
+import { useLocationState } from '@/hooks/useLocationState';
 import { TideForecast } from '@/services/tide/types';
 import { calculateSolarTimes } from '@/utils/solarUtils';
 import FishingCalendarHeader from '@/components/fishing/FishingCalendarHeader';
@@ -44,13 +44,10 @@ type DayFishingInfo = {
 const Calendar = () => {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [fishingInfo, setFishingInfo] = useState<Record<string, DayFishingInfo>>({});
-  const [currentLocation, setCurrentLocation] = useState<{ city: string; state: string; zipCode: string } | null>(() => {
-    // NO more fallback — begin with null so app prompts for user location
-    return null;
-  });
+  const { currentLocation, selectedStation } = useLocationState();
 
   // Fetch real tide data from NOAA
-  const { isLoading, error, weeklyForecast, stationName } = useTideData({ location: currentLocation });
+  const { isLoading, error, weeklyForecast, stationName } = useTideData({ location: currentLocation, station: selectedStation });
 
   // Helper function to add hours to a date
   const addHours = (date: Date, hours: number): Date => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -97,10 +97,11 @@ const Index = () => {
       <LoadingOverlay show={isStationLoading} message="Finding tide stations..." />
       <LoadingOverlay show={isLoading} message="Fetching tide data..." />
       
-      <AppHeader 
+      <AppHeader
         currentLocation={currentLocation}
         stationName={stationName}
         onLocationChange={handleLocationChange}
+        onStationSelect={handleStationSelect}
         onLocationClear={handleLocationClear}
         hasError={!!error}
         forceShowLocationSelector={showLocationSelector}
@@ -125,6 +126,7 @@ const Index = () => {
         isOpen={showStationPicker}
         stations={availableStations}
         onSelect={handleStationSelect}
+        currentStationId={selectedStation?.id || null}
         onClose={() => setShowStationPicker(false)}
       />
     </div>

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -1,7 +1,7 @@
 // src/services/locationService.ts
 
 import { getStationsForUserLocation } from "./noaaService";
-import { Station } from "./tide/stationService";
+import { Station, getStationById as fetchStationById } from "./tide/stationService";
 
 // Returns true if no stations for user location, false otherwise
 export async function isInlandLocation(userInput: string, stationId?: string): Promise<boolean> {
@@ -15,4 +15,8 @@ export async function isInlandLocation(userInput: string, stationId?: string): P
 // Returns all stations for the user's location input
 export async function getStationsForLocationInput(userInput: string): Promise<Station[]> {
   return getStationsForUserLocation(userInput);
+}
+
+export async function getStationById(id: string): Promise<Station | null> {
+  return fetchStationById(id);
 }

--- a/src/services/tide/stationService.ts
+++ b/src/services/tide/stationService.ts
@@ -35,3 +35,23 @@ export async function getStationsForLocation(
   cacheService.set(key, stations, STATION_CACHE_TTL);
   return stations;
 }
+
+export async function getStationById(id: string): Promise<Station | null> {
+  const key = `station:${id}`;
+  const cached = cacheService.get<Station>(key);
+  if (cached) return cached;
+
+  const response = await fetch(`/noaa-station/${id}`);
+  if (!response.ok) throw new Error('Unable to fetch station');
+  const data = await response.json();
+  if (!data.station) return null;
+  const station: Station = {
+    id: data.station.id,
+    name: data.station.name,
+    latitude: data.station.latitude,
+    longitude: data.station.longitude,
+    state: data.station.state,
+  };
+  cacheService.set(key, station, STATION_CACHE_TTL);
+  return station;
+}

--- a/src/utils/locationInputParser.ts
+++ b/src/utils/locationInputParser.ts
@@ -1,14 +1,20 @@
 import { normalizeState } from './stateNames';
 
 export type ParsedInput = {
-  type: 'zip' | 'cityState' | 'cityStateZip';
+  type: 'zip' | 'cityState' | 'cityStateZip' | 'stationId';
   zipCode?: string;
   city?: string;
   state?: string;
+  stationId?: string;
 };
 
 export const parseLocationInput = (input: string): ParsedInput | null => {
   const trimmed = input.trim();
+
+  // NOAA station id (6-7 digits)
+  if (/^\d{6,7}$/.test(trimmed)) {
+    return { type: 'stationId', stationId: trimmed };
+  }
   
   // ZIP code only (5 digits)
   if (/^\d{5}$/.test(trimmed)) {


### PR DESCRIPTION
## Summary
- allow station-id input in location parser
- display current station name in header
- show supported station ID format hint
- preselect current station in picker and allow manual station search
- store location & station across pages
- expose station lookup by id via proxy server

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68613e1c1e14832d86d76713911e6ffe