### PR TITLE
Fix station search and update onboarding

### DIFF
--- a/src/components/OnboardingInfo.tsx
+++ b/src/components/OnboardingInfo.tsx
@@ -45,6 +45,7 @@ const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
               <div>• Enter ZIP code: <code>02840</code></div>
               <div>• City/State: <code>Newport RI</code></div>
               <div>• Full format: <code>Newport RI 02840</code></div>
+              <div>• NOAA station ID: <code>8454000</code></div>
               <div>• Moon and solar data for all locations</div>
             </div>
           </div>
@@ -74,7 +75,7 @@ const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
               </Button>
             </DialogTitle>
             <DialogDescription>
-              Type a ZIP code, city and state, or both. Example: <code>02840</code>, <code>Newport RI</code>, or <code>Newport RI 02840</code>.
+              Type a ZIP code, city and state, or NOAA station ID. Example: <code>02840</code>, <code>Newport RI</code>, or <code>8454000</code>.
             </DialogDescription>
           </DialogHeader>
           

--- a/src/components/OnboardingMessage.tsx
+++ b/src/components/OnboardingMessage.tsx
@@ -44,6 +44,10 @@ const OnboardingMessage = ({ onGetStarted }: OnboardingMessageProps) => {
               <span>City/State: <code>Newport RI</code></span>
             </div>
             <div className="flex items-center justify-center gap-2">
+              <span>🌐</span>
+              <span>Station ID: <code>8454000</code></span>
+            </div>
+            <div className="flex items-center justify-center gap-2">
               <span>🌊</span>
               <span>Coastal ZIP codes provide tide data</span>
             </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,10 @@ export default defineConfig(({ mode }) => ({
               target: "http://localhost:3001",
               changeOrigin: true,
             },
+            "/noaa-station": {
+              target: "http://localhost:3001",
+              changeOrigin: true,
+            },
             "/tides": {
               target: "http://localhost:3001",
               changeOrigin: true,


### PR DESCRIPTION
## Summary
- proxy /noaa-station requests in dev server
- mention NOAA station IDs in onboarding instructions

## Testing
- `npm run lint` *(fails: Unexpected any and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861443e7b74832dafaa720ac74a9d60