### PR TITLE
Fix onboarding location display

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -66,6 +66,9 @@ export default function MainContent({
           date={currentDate}
           currentTime={currentTime}
           isLoading={isLoading}
+          currentLocation={currentLocation}
+          stationName={stationName}
+          stationId={stationId}
         />
       </div>
 
@@ -73,6 +76,9 @@ export default function MainContent({
         <WeeklyForecast
           forecast={weeklyForecast}
           isLoading={isLoading}
+          currentLocation={currentLocation}
+          stationName={stationName}
+          stationId={stationId}
         />
       </div>
     </main>

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -39,7 +39,7 @@ const MoonPhase = ({
   onGetStarted
 }: MoonPhaseProps) => {
   // Simplified location detection - just check if location exists and has basic data
-  const hasLocation = Boolean(currentLocation && (currentLocation.zipCode || (currentLocation.city && currentLocation.state)));
+  const hasLocation = Boolean(currentLocation && (currentLocation.zipCode || currentLocation.cityState));
 
   console.log('🌙 MoonPhase - Location check:', {
     hasCurrentLocation: !!currentLocation,

--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -14,6 +14,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2, MapPin } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TidePoint } from '@/services/tide/types';
+import LocationDisplay from './LocationDisplay';
+import { SavedLocation } from './LocationSelector';
 
 type TideChartProps = {
   curve: TidePoint[]; // continuous six-minute data
@@ -22,6 +24,9 @@ type TideChartProps = {
   currentTime?: string;
   isLoading?: boolean;
   className?: string;
+  currentLocation?: (SavedLocation & { id: string; country: string }) | null;
+  stationName?: string | null;
+  stationId?: string | null;
 };
 
 
@@ -40,7 +45,10 @@ const TideChart = ({
   date,
   currentTime,
   isLoading = false,
-  className
+  className,
+  currentLocation,
+  stationName,
+  stationId
 }: TideChartProps) => {
   const today = new Date(date + 'T00:00:00');
   if (isNaN(today.getTime())) {
@@ -111,6 +119,11 @@ const TideChart = ({
           <span>Tide Forecast</span>
           <span className="text-moon-blue text-sm">{date}</span>
         </CardTitle>
+        <LocationDisplay
+          currentLocation={currentLocation || null}
+          stationName={stationName || null}
+          stationId={stationId || null}
+        />
       </CardHeader>
       <CardContent>
         {isLoading ? (

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -4,6 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Info } from "lucide-react";
+import LocationDisplay from './LocationDisplay';
+import { SavedLocation } from './LocationSelector';
 import { getFullMoonName, isFullMoon, getMoonEmoji } from '@/utils/lunarUtils';
 import { formatApiDate } from '@/utils/dateTimeUtils';
 
@@ -24,9 +26,19 @@ type WeeklyForecastProps = {
   forecast: DayForecast[];
   isLoading?: boolean;
   className?: string;
+  currentLocation?: (SavedLocation & { id: string; country: string }) | null;
+  stationName?: string | null;
+  stationId?: string | null;
 };
 
-const WeeklyForecast = ({ forecast, isLoading = false, className }: WeeklyForecastProps) => {
+const WeeklyForecast = ({
+  forecast,
+  isLoading = false,
+  className,
+  currentLocation,
+  stationName,
+  stationId
+}: WeeklyForecastProps) => {
   // Get moon phase visual class
   const getMoonPhaseVisual = (phase: string) => {
     switch (phase) {
@@ -99,6 +111,11 @@ const WeeklyForecast = ({ forecast, isLoading = false, className }: WeeklyForeca
     <Card className={cn("overflow-hidden bg-card/50 backdrop-blur-md", className)}>
       <CardHeader>
         <CardTitle>7-Day Forecast</CardTitle>
+        <LocationDisplay
+          currentLocation={currentLocation || null}
+          stationName={stationName || null}
+          stationId={stationId || null}
+        />
       </CardHeader>
       <CardContent>
         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- show selected location info on tide and forecast cards
- use `currentLocation.cityState` to detect saved location

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68618a43146c832da33f08730a4aff7f