### PR TITLE
Fix location retention and duplicate history

### DIFF
--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -118,6 +118,28 @@ export const useLocationState = () => {
     );
   }, [currentLocation]);
 
+  // Sync state with storage on mount so navigation between pages keeps location
+  useEffect(() => {
+    const storedLocation = locationStorage.getCurrentLocation();
+    if (storedLocation) {
+      const converted = {
+        id: storedLocation.zipCode || `${storedLocation.city}-${storedLocation.state}`,
+        name: storedLocation.nickname || storedLocation.city,
+        country: 'USA',
+        zipCode: storedLocation.zipCode || '',
+        cityState: `${storedLocation.city}, ${storedLocation.state}`,
+        lat: storedLocation.lat || 0,
+        lng: storedLocation.lng || 0,
+      } as SavedLocation & { id: string; country: string };
+      setCurrentLocationWithLogging(converted);
+    }
+
+    const storedStation = safeLocalStorage.get(CURRENT_STATION_KEY) as Station | null;
+    if (storedStation && storedStation.id) {
+      setSelectedStationWithPersist(storedStation);
+    }
+  }, []);
+
   /* ---------- what the hook exposes ---------- */
 
   return {

--- a/src/utils/locationStorage.ts
+++ b/src/utils/locationStorage.ts
@@ -20,12 +20,15 @@ export const locationStorage = {
       const history = locationStorage.getLocationHistory();
       console.log('📚 Current history:', history);
       
-      // Remove any existing location with same zipCode or city/state combination
+      // Remove existing entries that match this location (case-insensitive)
+      const normalize = (val: string | undefined) => (val || '').trim().toLowerCase();
       const filtered = history.filter(loc => {
-        if (location.zipCode && loc.zipCode) {
-          return loc.zipCode !== location.zipCode;
-        }
-        return !(loc.city === location.city && loc.state === location.state);
+        const sameZip =
+          location.zipCode && loc.zipCode && normalize(loc.zipCode) === normalize(location.zipCode);
+        const sameCityState =
+          normalize(loc.city) === normalize(location.city) && normalize(loc.state) === normalize(location.state);
+
+        return !(sameZip || sameCityState);
       });
       
       const newHistory = [locationWithTimestamp, ...filtered].slice(0, 10); // Keep last 10


### PR DESCRIPTION
## Summary
- prevent duplicate saved locations by normalizing entries
- sync current location and station from storage when pages mount

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68618eb4cb7c832d8a4ee664bff50733