### PR TITLE
Fix 7-day forecast mobile layout

### DIFF
--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -74,15 +74,15 @@ const WeeklyForecast = ({
 
   const renderSkeletonForecast = () => {
     return Array(7).fill(0).map((_, index) => (
-      <div 
-        key={index} 
-        className="flex items-center p-3 rounded-md bg-muted/50"
+      <div
+        key={index}
+        className="flex flex-col sm:flex-row sm:items-center gap-2 p-3 rounded-md bg-muted/50"
       >
         <div className="w-20">
           <Skeleton className="h-5 w-12 mb-1" />
           <Skeleton className="h-3 w-10" />
         </div>
-        
+
         <div className="flex items-center space-x-3 flex-1">
           <Skeleton className="w-8 h-8 rounded-full" />
           <div>
@@ -90,8 +90,8 @@ const WeeklyForecast = ({
             <Skeleton className="h-4 w-24" />
           </div>
         </div>
-        
-        <div className="grid grid-cols-2 gap-3">
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full sm:w-auto">
           <div>
             <Skeleton className="h-3 w-14 mb-1" />
             <Skeleton className="h-4 w-8 mb-1" />
@@ -136,10 +136,10 @@ const WeeklyForecast = ({
               const fullMoonName = isFullMoon(day.moonPhase) ? getFullMoonName(dayDate) : null;
               
               return (
-                <div 
-                  key={index} 
+                <div
+                  key={index}
                   className={cn(
-                    "flex items-center p-3 rounded-md", 
+                    "flex flex-col sm:flex-row sm:items-center gap-2 p-3 rounded-md",
                     index === 0 ? "bg-muted" : "hover:bg-muted transition-colors"
                   )}
                 >
@@ -148,7 +148,7 @@ const WeeklyForecast = ({
                     <p className="font-medium">{day.day}</p>
                     <p className="text-xs text-muted-foreground">{day.date}</p>
                   </div>
-                  
+
                   {/* Moon Phase */}
                   <div className="flex items-center space-x-3 flex-1">
                     <div className={`w-8 h-8 rounded-full ${getMoonPhaseVisual(day.moonPhase)}`}></div>
@@ -167,7 +167,7 @@ const WeeklyForecast = ({
                   </div>
                   
                   {/* Tide Info - display two low-high cycles per day */}
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full sm:w-auto mt-2 sm:mt-0">
                     {day.cycles.map((cycle, idx) => (
                       <div key={idx} className="text-sm">
                         <p className="text-xs text-muted-foreground mb-1">Cycle {idx + 1}</p>


### PR DESCRIPTION
## Summary
- adjust WeeklyForecast layout for small screens

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686274f41e50832d81fcf29a1db1e655