### PR TITLE
Fix station lookup filter for zip and city

### DIFF
--- a/moontide-proxy/noaaStations.ts
+++ b/moontide-proxy/noaaStations.ts
@@ -47,6 +47,8 @@ const lookupCache = new Map<string, { stations: StationResult[]; expiry: number 
 
 const GEO_TTL = 24 * 60 * 60 * 1000; // 24 hours
 const LOOKUP_TTL = 12 * 60 * 60 * 1000; // 12 hours
+// Maximum distance in kilometers for stations to be considered "near" a location
+const MAX_DISTANCE_KM = 30; // roughly 18 miles
 
 async function loadStations(): Promise<StationMeta[]> {
   if (stationCache) {
@@ -227,6 +229,11 @@ router.get('/noaa-stations', async (req, res) => {
         distance: haversine(coords.lat, coords.lng, s.lat, s.lng),
       };
     });
+
+
+    // Always filter to stations within a reasonable distance of the
+    // geocoded location to avoid results far outside the requested area.
+    processed = processed.filter((p) => p.distance <= MAX_DISTANCE_KM);
 
     if (isZip) {
       processed = processed.filter((p) => p.zip === input.trim());


### PR DESCRIPTION
## Summary
- limit station search results to locations within 30km of the geocode
- keep ZIP code filter after applying distance check

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`
- `cd moontide-proxy && npm run build`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68627c62cfc4832da3060513d8bbab91