### PR TITLE
Fix duplicate NOAA locations in picker

### DIFF
--- a/src/components/EnhancedLocationInput.tsx
+++ b/src/components/EnhancedLocationInput.tsx
@@ -33,19 +33,14 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
 
   const handleLocationSelect = (location: LocationData) => {
     console.log('📍 Location selected via UnifiedLocationInput:', location);
-    
-    // Save to storage
-    locationStorage.saveCurrentLocation(location);
-    
-    // Update local state
+
+    // Update local state based on latest history after parent saves
+    onLocationSelect(location);
     const history = locationStorage.getLocationHistory();
     setSavedLocations(history as SavedLocationWithNickname[]);
-    
-    onLocationSelect(location);
   };
 
   const handleSavedLocationSelect = (location: SavedLocationWithNickname) => {
-    locationStorage.saveCurrentLocation(location);
     onLocationSelect(location);
     toast.success(`Using ${location.nickname || location.city}`);
   };

--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -30,10 +30,11 @@ export const useLocationManager = ({ setCurrentLocation, setShowLocationSelector
     try {
       safeLocalStorage.set(CURRENT_LOCATION_KEY, updatedLocation);
       
+      const parsedState = updatedLocation.cityState.split(', ')[1] || '';
       const locationData: LocationData = {
         zipCode: updatedLocation.zipCode,
         city: updatedLocation.name,
-        state: updatedLocation.cityState.split(', ')[1] || 'Unknown',
+        state: parsedState,
         lat: updatedLocation.lat,
         lng: updatedLocation.lng,
         isManual: false,

--- a/src/components/OnboardingInfo.tsx
+++ b/src/components/OnboardingInfo.tsx
@@ -4,7 +4,6 @@ import { Info, Search, X } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import UnifiedLocationInput from './UnifiedLocationInput';
 import { LocationData } from '@/types/locationTypes';
-import { locationStorage } from '@/utils/locationStorage';
 
 type OnboardingInfoProps = {
   onGetStarted: (location?: LocationData) => void;
@@ -20,10 +19,6 @@ const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
 
   const handleLocationSelect = (location: LocationData) => {
     console.log('🔄 OnboardingInfo: Location selected:', location);
-
-    // Save the location
-    locationStorage.saveCurrentLocation(location);
-    console.log('💾 OnboardingInfo: Location saved to storage');
 
     // Close modal and trigger location change
     setShowLocationModal(false);


### PR DESCRIPTION
## Summary
- avoid saving locations twice when selecting
- don't save location during onboarding
- handle missing state properly in `LocationManager`

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862a8febb68832d82fc35334046ff61