### PR TITLE
Fix NOAA fetch via proxy

### DIFF
--- a/src/services/tide/tideService.ts
+++ b/src/services/tide/tideService.ts
@@ -51,8 +51,20 @@ const buildUrl = (p: QueryParams) =>
 /* ---------- core fetch ---------- */
 
 async function tryFetch(url: string) {
+  const config = getProxyConfig();
+  let fetchUrl = url;
+
+  // When running in the browser, route through a proxy to avoid CORS issues
+  if (typeof window !== 'undefined') {
+    if (config.useLocalProxy) {
+      fetchUrl = `${config.localProxyUrl}?url=${encodeURIComponent(url)}`;
+    } else if (config.fallbackProxyUrl) {
+      fetchUrl = `${config.fallbackProxyUrl}${encodeURIComponent(url)}`;
+    }
+  }
+
   try {
-    const r = await fetch(url);
+    const r = await fetch(fetchUrl);
     if (!r.ok) return { rows: null, err: `HTTP ${r.status}` };
     const data = await r.json();
     const rows = data.predictions ?? data.data ?? null;


### PR DESCRIPTION
## Summary
- route tide service calls through proxy when in browser

## Testing
- `npm run lint` *(fails: 27 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6862ad22e2c0832d84b1989d0623f8d6