### PR TITLE
Fix React hooks error by reverting ScrollArea usage

### DIFF
--- a/src/components/EnhancedLocationInput.tsx
+++ b/src/components/EnhancedLocationInput.tsx
@@ -7,7 +7,6 @@ import { toast } from 'sonner';
 import { locationStorage } from '@/utils/locationStorage';
 import { LocationData } from '@/types/locationTypes';
 import UnifiedLocationInput from './UnifiedLocationInput';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Station } from '@/services/tide/stationService';
 
 interface EnhancedLocationInputProps {
@@ -91,8 +90,7 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
       {savedLocations.length > 0 && (
         <div className="space-y-2">
           <h4 className="text-sm font-medium">Recent Locations</h4>
-          <ScrollArea className="max-h-48">
-            <div className="space-y-1">
+          <div className="max-h-48 overflow-y-auto space-y-1">
             {savedLocations.slice(0, 8).map((location, index) => {
               const locationKey = location.zipCode || location.city;
               return (
@@ -148,9 +146,8 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
               );
             })}
             </div>
-          </ScrollArea>
-        </div>
-      )}
-    </div>
-  );
+          </div>
+        )}
+      </div>
+    );
 }

--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -2,7 +2,6 @@
 import React, { useState } from 'react';
 import { MapPin, Clock, Edit, Trash2, MoreVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
 import { locationStorage } from '@/utils/locationStorage';
@@ -100,8 +99,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
 
   return (
     <>
-      <ScrollArea className="max-h-64">
-        <div className="space-y-2">
+      <div className="space-y-2 max-h-64 overflow-y-auto">
         {locationHistory.map((location, index) => {
           const isCurrent = currentLocation?.zipCode === location.zipCode || 
                            (currentLocation?.city === location.city && currentLocation?.state === location.state);
@@ -166,8 +164,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
             </div>
           );
         })}
-        </div>
-      </ScrollArea>
+      </div>
 
       {editingLocation && (
         <LocationEditModal


### PR DESCRIPTION
## Summary
- remove ScrollArea wrappers from location menus
- revert to simple div containers for saved locations

## Testing
- `npm run lint` *(fails: unexpected any errors in multiple files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862cfe43fe4832da8ae1e4ee0ed3dc5