### PR TITLE
Limit location list height for easier scrolling

### DIFF
--- a/src/components/EnhancedLocationInput.tsx
+++ b/src/components/EnhancedLocationInput.tsx
@@ -90,7 +90,7 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
       {savedLocations.length > 0 && (
         <div className="space-y-2">
           <h4 className="text-sm font-medium">Recent Locations</h4>
-          <div className="max-h-48 overflow-y-auto space-y-1">
+          <div className="max-h-40 overflow-y-auto space-y-1">
             {savedLocations.slice(0, 8).map((location, index) => {
               const locationKey = location.zipCode || location.city;
               return (

--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -99,7 +99,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
 
   return (
     <>
-      <div className="space-y-2 max-h-64 overflow-y-auto">
+      <div className="space-y-2 max-h-40 overflow-y-auto">
         {locationHistory.map((location, index) => {
           const isCurrent = currentLocation?.zipCode === location.zipCode || 
                            (currentLocation?.city === location.city && currentLocation?.state === location.state);

--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -80,7 +80,7 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose, cur
             <SelectTrigger>
               <SelectValue placeholder="Choose station" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="max-h-40">
               {stations.map((s) => (
                 <SelectItem key={s.id} value={s.id}>
                   {s.name}


### PR DESCRIPTION
## Summary
- show only the first three entries in recent/saved locations and tide station selector
- allow scrolling when there are more entries so the top of long lists is visible

## Testing
- `npx eslint src/components/StationPicker.tsx src/components/SavedLocationsList.tsx src/components/EnhancedLocationInput.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862d9c9e694832db58d327d1efde456