### PR TITLE
Fix tide time display to ignore timezone shifts

### DIFF
--- a/src/components/TideTable.tsx
+++ b/src/components/TideTable.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { Station } from '@/services/tide/stationService';
+import { formatIsoToAmPm } from '@/utils/dateTimeUtils';
 
 export interface TideReading {
   time: string;   // ISO 8601
@@ -19,13 +20,7 @@ interface Props {
 }
 
 const TideTable: React.FC<Props> = ({ loading, station, readings }) => {
-  const formatTimeToAMPM = (timeString: string) => {
-    return new Date(timeString).toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true
-    });
-  };
+  const formatTimeToAMPM = (timeString: string) => formatIsoToAmPm(timeString);
 
   if (loading) {
     return (

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -7,7 +7,7 @@ import { Info } from "lucide-react";
 import LocationDisplay from './LocationDisplay';
 import { SavedLocation } from './LocationSelector';
 import { getFullMoonName, isFullMoon, getMoonEmoji } from '@/utils/lunarUtils';
-import { formatApiDate } from '@/utils/dateTimeUtils';
+import { formatApiDate, formatIsoToAmPm } from '@/utils/dateTimeUtils';
 
 type TideCycle = {
   low: { time: string; height: number };
@@ -63,14 +63,11 @@ const WeeklyForecast = ({
     }
   };
 
-  const formatTimeToAMPM = (timeString: string) => {
-    const date = new Date(timeString);
-    return date.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
-  };
+  // NOAA provides times without any timezone information and in the station's
+  // local time zone. Using the JS Date constructor would incorrectly interpret
+  // them as UTC and shift the displayed time. Instead, format the raw string
+  // directly without timezone conversion.
+  const formatTimeToAMPM = (timeString: string) => formatIsoToAmPm(timeString);
 
   const renderSkeletonForecast = () => {
     return Array(7).fill(0).map((_, index) => (

--- a/src/components/fishing/FishingWindows.tsx
+++ b/src/components/fishing/FishingWindows.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Badge } from "@/components/ui/badge";
+import { formatIsoToAmPm } from '@/utils/dateTimeUtils';
 
 type FishingWindow = {
   start: string;
@@ -14,14 +15,7 @@ type FishingWindowsProps = {
 };
 
 const FishingWindows: React.FC<FishingWindowsProps> = ({ windows }) => {
-  const formatTimeToAMPM = (timeString: string) => {
-    const date = new Date(timeString);
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true
-    });
-  };
+  const formatTimeToAMPM = (timeString: string) => formatIsoToAmPm(timeString);
 
   return (
     <div>

--- a/src/components/fishing/LightConditions.tsx
+++ b/src/components/fishing/LightConditions.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { formatIsoToAmPm } from '@/utils/dateTimeUtils';
 
 type LightConditionsProps = {
   sunrise: string;
@@ -7,14 +8,7 @@ type LightConditionsProps = {
 };
 
 const LightConditions: React.FC<LightConditionsProps> = ({ sunrise, sunset }) => {
-  const formatTimeToAMPM = (timeString: string) => {
-    const date = new Date(timeString);
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true
-    });
-  };
+  const formatTimeToAMPM = (timeString: string) => formatIsoToAmPm(timeString);
 
   return (
     <div>

--- a/src/components/fishing/TideInfo.tsx
+++ b/src/components/fishing/TideInfo.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { formatIsoToAmPm } from '@/utils/dateTimeUtils';
 
 type TideInfoProps = {
   tides: {
@@ -9,14 +10,7 @@ type TideInfoProps = {
 };
 
 const TideInfo: React.FC<TideInfoProps> = ({ tides }) => {
-  const formatTimeToAMPM = (timeString: string) => {
-    const date = new Date(timeString);
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true
-    });
-  };
+  const formatTimeToAMPM = (timeString: string) => formatIsoToAmPm(timeString);
 
   return (
     <div>

--- a/src/utils/dateTimeUtils.ts
+++ b/src/utils/dateTimeUtils.ts
@@ -45,6 +45,33 @@ export const formatTimeToAmPm = (timeString: string): string => {
   
   const period = hours >= 12 ? 'PM' : 'AM';
   const displayHour = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
-  
+
   return `${displayHour}:${minutes.toString().padStart(2, '0')} ${period}`;
+};
+
+// Format an ISO date-time string ("YYYY-MM-DDTHH:MM:SS") to 12-hour time
+// without applying any timezone conversion. NOAA predictions are returned
+// in the station's local time without a timezone offset, so treating them
+// as UTC results in shifted times. This helper simply parses the hour and
+// minute portion and formats it directly.
+export const formatIsoToAmPm = (isoString: string): string => {
+  const timePart = isoString.split('T')[1];
+  if (!timePart) return isoString;
+  const [hourStr, minuteStr] = timePart.split(':');
+  const hours = Number(hourStr);
+  const minutes = Number(minuteStr);
+  if (isNaN(hours) || isNaN(minutes)) return isoString;
+  const period = hours >= 12 ? 'PM' : 'AM';
+  const displayHour = hours % 12 === 0 ? 12 : hours % 12;
+  return `${displayHour}:${minuteStr.padStart(2, '0')} ${period}`;
+};
+
+// Parse an ISO string like "YYYY-MM-DDTHH:MM:SS" as if it were in the local
+// timezone rather than UTC. This keeps the hour/minute values intact so tide
+// times from NOAA display correctly.
+export const parseIsoAsLocal = (isoString: string): Date => {
+  const [datePart, timePart] = isoString.split('T');
+  const [y, m, d] = datePart.split('-').map(Number);
+  const [h = 0, mi = 0, s = 0] = timePart.split(':').map(Number);
+  return new Date(y, m - 1, d, h, mi, s);
 };


### PR DESCRIPTION
## Summary
- keep NOAA tide times in the station's local timezone
- add helpers to format and parse ISO times without timezone conversion
- update components to use the new helpers when displaying times

## Testing
- `npm run lint` *(fails: prefer-const, unexpected any, etc.)*
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862eb2330d0832da9ea07e508b20ef6