### PR TITLE
Fix tide chart date conversion

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -6,6 +6,7 @@ import { Station } from '@/services/tide/stationService';
 import {
   getCurrentIsoDateString,
   getCurrentTimeString,
+  formatDateAsLocalIso,
 } from '@/utils/dateTimeUtils';
 import { TidePoint, TideForecast, TideCycle, TideEvent } from '@/services/tide/types';
 import { calculateMoonPhase } from '@/utils/lunarUtils';
@@ -97,7 +98,7 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
         }
         const startDate = new Date();
         startDate.setDate(startDate.getDate() - 1); // include prior day for smoother charts
-        const dateIso = startDate.toISOString().split('T')[0];
+        const dateIso = formatDateAsLocalIso(startDate);
         console.log('🌐 useTideData getTideData:', {
           stationId: chosen.id,
           date: dateIso

--- a/src/utils/dateTimeUtils.ts
+++ b/src/utils/dateTimeUtils.ts
@@ -10,8 +10,14 @@ export const getCurrentDateString = (): string => {
   });
 };
 
+const pad = (n: number) => n.toString().padStart(2, '0');
+
+export const formatDateAsLocalIso = (date: Date): string => {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
+
 export const getCurrentIsoDateString = (): string => {
-  return new Date().toISOString().split('T')[0];
+  return formatDateAsLocalIso(new Date());
 };
 
 export const getCurrentTimeString = (): string => {


### PR DESCRIPTION
## Summary
- ensure date strings use local calendar day
- use new helper in `useTideData` to fetch data for the correct day

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863ee831ac0832d960a2cc2a96e0afa