### PR TITLE
Fix tide chart axis

### DIFF
--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import { TidePoint, TideCycle } from '@/services/tide/types';
 import LocationDisplay from './LocationDisplay';
 import { SavedLocation } from './LocationSelector';
-import { formatIsoToAmPm, parseIsoAsLocal } from '@/utils/dateTimeUtils';
+import { formatIsoToAmPm, parseIsoAsLocal, formatDateTimeAsLocalIso } from '@/utils/dateTimeUtils';
 
 type TideChartProps = {
   curve: TidePoint[]; // continuous six-minute data
@@ -59,6 +59,13 @@ const TideChart = ({
   startOfDay.setHours(0, 0, 0, 0);
   const endOfDay = new Date(startOfDay);
   endOfDay.setDate(endOfDay.getDate() + 1);
+
+  const tickValues: number[] = [];
+  for (let h = 0; h <= 24; h += 6) {
+    const d = new Date(startOfDay);
+    d.setHours(h, 0, 0, 0);
+    tickValues.push(d.getTime());
+  }
 
   const allPoints = (curve || [])
     .map((tp) => ({ ...tp, ts: parseIsoAsLocal(tp.time).getTime() }))
@@ -180,7 +187,10 @@ const TideChart = ({
                   dataKey="ts"
                   type="number"
                   domain={[startOfDay.getTime(), endOfDay.getTime()]}
-                  tickFormatter={(t) => formatIsoToAmPm(new Date(t).toISOString())}
+                  tickFormatter={(t) =>
+                    formatIsoToAmPm(formatDateTimeAsLocalIso(new Date(t)))
+                  }
+                  ticks={tickValues}
                   tick={{ fill: '#cbd5e1', fontSize: 12 }}
                   axisLine={{ stroke: '#475569' }}
                 />

--- a/src/utils/dateTimeUtils.ts
+++ b/src/utils/dateTimeUtils.ts
@@ -81,3 +81,8 @@ export const parseIsoAsLocal = (isoString: string): Date => {
   const [h = 0, mi = 0, s = 0] = timePart.split(':').map(Number);
   return new Date(y, m - 1, d, h, mi, s);
 };
+
+export const formatDateTimeAsLocalIso = (date: Date): string => {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};


### PR DESCRIPTION
## Summary
- ensure chart x-axis ticks use local time
- add tick values for 12AM–6AM–12PM–6PM–12AM

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 27 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863f267311c832d90ac97cb12eb4a4c