### PR TITLE
Fix tide tooltip time offset

### DIFF
--- a/src/components/TideChart.tsx
+++ b/src/components/TideChart.tsx
@@ -32,11 +32,12 @@ type TideChartProps = {
 
 
 // NOAA prediction times omit timezone information and are already in the
-// station's local time. Using the Date constructor would treat them as UTC
-// and skew the displayed values. Format the raw string directly instead.
+// station's local time. Using `toISOString()` converts the timestamp to UTC,
+// causing hover tooltips to be offset from the chart. Format using the local
+// time components instead.
 const formatTimeToAMPM = (time: string | number) =>
   typeof time === 'number'
-    ? formatIsoToAmPm(new Date(time).toISOString())
+    ? formatIsoToAmPm(formatDateTimeAsLocalIso(new Date(time)))
     : formatIsoToAmPm(String(time));
 
 const TideChart = ({


### PR DESCRIPTION
## Summary
- ensure tide chart tooltip formats local time without UTC shift

## Testing
- `npm run lint -- --fix` *(fails: Unexpected any etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863f743f724832da041db96d0bbe391