### PR TITLE
Add nickname support for locations

### DIFF
--- a/src/components/EnhancedLocationInput.tsx
+++ b/src/components/EnhancedLocationInput.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Edit, Save, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { locationStorage } from '@/utils/locationStorage';
 import { LocationData } from '@/types/locationTypes';
@@ -24,6 +25,7 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
   const [savedLocations, setSavedLocations] = useState<SavedLocationWithNickname[]>([]);
   const [editingNickname, setEditingNickname] = useState<string | null>(null);
   const [nicknameInput, setNicknameInput] = useState('');
+  const [newNickname, setNewNickname] = useState('');
 
   // Load saved locations on mount
   useEffect(() => {
@@ -34,10 +36,16 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
   const handleLocationSelect = (location: LocationData) => {
     console.log('📍 Location selected via UnifiedLocationInput:', location);
 
+    const withNickname = {
+      ...location,
+      nickname: newNickname.trim() || undefined
+    };
+
     // Update local state based on latest history after parent saves
-    onLocationSelect(location);
+    onLocationSelect(withNickname);
     const history = locationStorage.getLocationHistory();
     setSavedLocations(history as SavedLocationWithNickname[]);
+    setNewNickname('');
   };
 
   const handleSavedLocationSelect = (location: SavedLocationWithNickname) => {
@@ -85,6 +93,16 @@ export default function EnhancedLocationInput({ onLocationSelect, onStationSelec
         onClose={onClose}
         placeholder="02840 or Newport, RI"
       />
+      <div className="-mt-2 space-y-2">
+        <Label htmlFor="new-nickname" className="text-xs">Custom Name (Optional)</Label>
+        <Input
+          id="new-nickname"
+          value={newNickname}
+          onChange={(e) => setNewNickname(e.target.value)}
+          placeholder="e.g., Work"
+          className="h-8"
+        />
+      </div>
 
       {/* Recent Locations */}
       {savedLocations.length > 0 && (

--- a/src/components/LocationEditModal.tsx
+++ b/src/components/LocationEditModal.tsx
@@ -85,7 +85,6 @@ export default function LocationEditModal({ location, isOpen, onClose, onSave }:
               id="zipCode"
               value={zipCode}
               onChange={(e) => setZipCode(e.target.value)}
-              required
             />
           </div>
         </div>
@@ -94,7 +93,7 @@ export default function LocationEditModal({ location, isOpen, onClose, onSave }:
           <Button variant="outline" onClick={handleCancel}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={!city.trim() || !state.trim() || !zipCode.trim()}>
+          <Button onClick={handleSave} disabled={!city.trim() || !state.trim()}>
             Save Changes
           </Button>
         </DialogFooter>

--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -30,15 +30,15 @@ export const useLocationManager = ({ setCurrentLocation, setShowLocationSelector
     try {
       safeLocalStorage.set(CURRENT_LOCATION_KEY, updatedLocation);
       
-      const parsedState = updatedLocation.cityState.split(', ')[1] || '';
+      const [actualCity, actualState] = updatedLocation.cityState.split(', ');
       const locationData: LocationData = {
         zipCode: updatedLocation.zipCode,
-        city: updatedLocation.name,
-        state: parsedState,
+        city: actualCity || updatedLocation.name,
+        state: actualState || '',
         lat: updatedLocation.lat,
         lng: updatedLocation.lng,
         isManual: false,
-        nickname: updatedLocation.name
+        nickname: updatedLocation.name !== actualCity ? updatedLocation.name : undefined
       };
       locationStorage.saveCurrentLocation(locationData);
       

--- a/src/components/OnboardingInfo.tsx
+++ b/src/components/OnboardingInfo.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from "@/components/ui/button";
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Info, Search, X } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import UnifiedLocationInput from './UnifiedLocationInput';
@@ -11,6 +13,7 @@ type OnboardingInfoProps = {
 
 const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
   const [showLocationModal, setShowLocationModal] = useState(false);
+  const [nickname, setNickname] = useState('');
 
   const handleEnterLocationClick = () => {
     console.log('🔄 OnboardingInfo: Enter Your Location button clicked');
@@ -20,9 +23,15 @@ const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
   const handleLocationSelect = (location: LocationData) => {
     console.log('🔄 OnboardingInfo: Location selected:', location);
 
+    const withNickname = {
+      ...location,
+      nickname: nickname.trim() || undefined
+    };
+
     // Close modal and trigger location change
     setShowLocationModal(false);
-    onGetStarted(location);
+    onGetStarted(withNickname);
+    setNickname('');
   };
 
   const handleModalClose = () => {
@@ -81,6 +90,15 @@ const OnboardingInfo = ({ onGetStarted }: OnboardingInfoProps) => {
             placeholder="02840 or Newport RI"
             autoFocus={true}
           />
+          <div className="mt-4 space-y-2">
+            <Label htmlFor="onboard-nickname">Custom Name (Optional)</Label>
+            <Input
+              id="onboard-nickname"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              placeholder="e.g., Home"
+            />
+          </div>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## Summary
- allow nickname entry during onboarding and when adding locations
- include nickname field in add new location interface
- save nicknames correctly in location manager
- remove ZIP requirement to edit location names

## Testing
- `npm run lint` *(fails: several type errors and lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6863fbe004cc832d95d2c79fd30c1b42