### PR TITLE
Fix calendar back navigation

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,7 +14,7 @@ import { Station } from '@/services/tide/stationService';
 
 const Index = () => {
   console.log('🚀 Index component rendering...');
-  
+
   const {
     currentLocation,
     setCurrentLocation,
@@ -23,6 +23,11 @@ const Index = () => {
     selectedStation,
     setSelectedStation
   } = useLocationState();
+
+  // Ensure the location selector is closed when arriving on the dashboard
+  useEffect(() => {
+    setShowLocationSelector(false);
+  }, []);
 
   const {
     handleLocationChange,


### PR DESCRIPTION
## Summary
- prevent the location selector from opening when returning to the dashboard

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863ffe13710832d9a84778f9c0bd249