### PR TITLE
Fix location selector flash on dashboard

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useState, useRef } from 'react';
 import { toast } from 'sonner';
 import AppHeader from '@/components/AppHeader';
 import MainContent from '@/components/MainContent';
@@ -25,7 +25,7 @@ const Index = () => {
   } = useLocationState();
 
   // Ensure the location selector is closed when arriving on the dashboard
-  useEffect(() => {
+  useLayoutEffect(() => {
     setShowLocationSelector(false);
   }, []);
 


### PR DESCRIPTION
## Summary
- stop location picker from flashing when navigating from calendar to dashboard

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686404b06aa4832dade097d8899361d6