### PR TITLE
Fix location selector persistence

### DIFF
--- a/src/hooks/useLocationState.tsx
+++ b/src/hooks/useLocationState.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useLocation as useRouterLocation } from 'react-router-dom';
 import { SavedLocation } from '@/components/LocationSelector';
 import { safeLocalStorage } from '@/utils/localStorage';
 import { locationStorage } from '@/utils/locationStorage';
@@ -68,6 +69,13 @@ export const useLocationState = () => {
       return null;
     }
   });
+
+  const routerLocation = useRouterLocation();
+
+  // Close any open location selector when navigating to a new route
+  useEffect(() => {
+    setShowLocationSelector(false);
+  }, [routerLocation.pathname]);
 
   /* ---------- setters with logging / persistence ---------- */
 

--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -72,12 +72,7 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
     if (!location || !station) {
       setIsLoading(false);
       setError(null);
-      setTideData([]);
-      setTideEvents([]);
-      setWeeklyForecast([]);
-      setStationName(null);
-      setStationId(null);
-      setIsInland(false);
+      // Keep previously loaded data so navigating away doesn't clear charts
       return;
     }
 


### PR DESCRIPTION
## Summary
- maintain tide data if user closes location selector
- close open location selector on route changes

## Testing
- `npm run lint` *(fails: Unexpected any rules)*

------
https://chatgpt.com/codex/tasks/task_e_68640883e800832da777fb975249b623