### PR TITLE
Fix responsive layout for fishing calendar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -145,5 +145,25 @@
   .day-optimal-fishing {
     @apply border-2 !border-moon-primary;
   }
+
+  /* Responsive calendar layout */
+  .rdp {
+    width: 100%;
+  }
+  .rdp-months {
+    width: 100%;
+  }
+  .rdp-table {
+    width: 100%;
+    max-width: none;
+    table-layout: fixed;
+  }
+  .rdp-day,
+  .rdp-weeknumber {
+    width: auto;
+    max-width: none;
+    aspect-ratio: 1/1;
+    height: auto;
+  }
 }
 

--- a/src/pages/FishingCalendar.tsx
+++ b/src/pages/FishingCalendar.tsx
@@ -197,7 +197,7 @@ const Calendar = () => {
           </div>
         )}
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="w-full">
           <CalendarCard selectedDate={selectedDate} />
         </div>
 


### PR DESCRIPTION
## Summary
- ensure the fishing calendar fills the available width
- adjust DayPicker styles to stretch with the screen

## Testing
- `npm run lint` *(fails: prefer-const and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686412b3e16c832dbbd4f93957af4f08