### PR TITLE
Fix LocationManager import

### DIFF
--- a/src/components/LocationManager.tsx
+++ b/src/components/LocationManager.tsx
@@ -12,7 +12,7 @@ interface LocationManagerProps {
   setShowLocationSelector: (show: boolean) => void;
 }
 
-export const useLocationManager = ({ setCurrentLocation, setShowLocationSelector }: LocationManagerProps) => {
+const LocationManager = ({ setCurrentLocation, setShowLocationSelector }: LocationManagerProps) => {
   const handleLocationChange = (location: SavedLocation) => {
     console.log('🔄 LocationManager: Location change requested:', location);
     
@@ -92,6 +92,8 @@ export const useLocationManager = ({ setCurrentLocation, setShowLocationSelector
   return {
     handleLocationChange,
     handleLocationClear,
-    handleGetStarted
+    handleGetStarted,
   };
 };
+
+export default LocationManager;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,7 +7,7 @@ import StarsBackdrop from '@/components/StarsBackdrop';
 import LoadingOverlay from '@/components/LoadingOverlay';
 import { useTideData } from '@/hooks/useTideData';
 import { useLocationState } from '@/hooks/useLocationState';
-import { useLocationManager } from '@/components/LocationManager';
+import LocationManager from '@/components/LocationManager';
 import StationPicker from '@/components/StationPicker';
 import { getStationsForLocationInput } from '@/services/locationService';
 import { Station } from '@/services/tide/stationService';
@@ -32,8 +32,8 @@ const Index = () => {
   const {
     handleLocationChange,
     handleLocationClear,
-    handleGetStarted
-  } = useLocationManager({ setCurrentLocation, setShowLocationSelector });
+    handleGetStarted,
+  } = LocationManager({ setCurrentLocation, setShowLocationSelector });
 
   const [availableStations, setAvailableStations] = useState<Station[]>([]);
   const [showStationPicker, setShowStationPicker] = useState(false);


### PR DESCRIPTION
## Summary
- rename `useLocationManager` to default export `LocationManager`
- update dashboard page to import default export

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864430d8eec832dbbd5b500d73d956f