### PR TITLE
Fix weekly forecast cycle grouping

### DIFF
--- a/src/hooks/useTideData.tsx
+++ b/src/hooks/useTideData.tsx
@@ -156,7 +156,7 @@ export const useTideData = ({ location, station }: UseTideDataParams): UseTideDa
           };
 
           if (prevEvent) {
-            const date = event.time.slice(0, 10);
+            const date = prevEvent.time.slice(0, 10);
             if (!cyclesByDate[date]) cyclesByDate[date] = [];
             cyclesByDate[date].push({
               first: prevEvent,


### PR DESCRIPTION
## Summary
- fix day cycle assignment by using the first event's date when grouping

## Testing
- `npm run lint` *(fails: Unexpected any & no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6864477ee8b8832dafda2f53facb66e9