### PR TITLE
Use NOAA API directly in production

### DIFF
--- a/src/components/StationPicker.tsx
+++ b/src/components/StationPicker.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { toast } from 'sonner';
 import { Station } from '@/services/tide/stationService';
+import { IS_DEV } from '@/services/env';
 
 interface StationPickerProps {
   isOpen: boolean;
@@ -40,7 +41,10 @@ export default function StationPicker({ isOpen, stations, onSelect, onClose, cur
   const handleManualSearch = async () => {
     if (!manualId.trim()) return;
     try {
-      const response = await fetch(`/noaa-station/${manualId.trim()}`);
+      const url = IS_DEV
+        ? `/noaa-station/${manualId.trim()}`
+        : `https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/${manualId.trim()}.json`;
+      const response = await fetch(url);
       if (!response.ok) {
         toast.error('Station not found');
         return;

--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -1,0 +1,2 @@
+export const IS_DEV = process.env.NODE_ENV === 'development';
+

--- a/src/services/tide/proxyConfig.ts
+++ b/src/services/tide/proxyConfig.ts
@@ -8,10 +8,13 @@ export interface ProxyConfig {
 }
 
 // Updated configuration with better fallback options
+import { IS_DEV } from '../env';
+
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
-  useLocalProxy: false, // Keep false to avoid localhost dependency
+  useLocalProxy: IS_DEV,
   localProxyUrl: 'http://localhost:3001/api/noaa',
-  fallbackProxyUrl: 'https://corsproxy.io/?',
+  // Only use the CORS proxy during development to work around local restrictions
+  fallbackProxyUrl: IS_DEV ? 'https://corsproxy.io/?' : '',
   corsProxyUrl: 'https://cors-anywhere.herokuapp.com/'
 };
 


### PR DESCRIPTION
## Summary
- add `IS_DEV` flag to detect development mode
- route NOAA requests through proxy only in dev
- switch station and tide lookups to live NOAA URLs when not in dev
- update manual station search logic for production

## Testing
- `npm run lint` *(fails: 27 errors, 13 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866ae1287e4832dbfb626ba06ca1b60