### PR TITLE
Fix production API paths by detecting Vite mode

### DIFF
--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -1,2 +1,13 @@
-export const IS_DEV = process.env.NODE_ENV === 'development';
+// src/services/env.ts
+// -----------------------------------------------------------
+// Determine whether we're running in development mode.
+// Vite exposes `import.meta.env.MODE` which is reliably set to
+// "development" when built with `vite dev` or `--mode development`.
+// Capacitor builds sometimes miss `process.env.NODE_ENV`, so check
+// both values to decide.
+
+const nodeEnv = typeof process !== 'undefined' ? process.env.NODE_ENV : undefined;
+const viteMode = typeof import.meta !== 'undefined' ? import.meta.env.MODE : undefined;
+
+export const IS_DEV = nodeEnv === 'development' || viteMode === 'development';
 


### PR DESCRIPTION
## Summary
- detect dev mode using `import.meta.env.MODE` fallback

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866bb0505a8832da5a3e9f90ec094be