### PR TITLE
fix IS_DEV detection

### DIFF
--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -6,8 +6,10 @@
 // Capacitor builds sometimes miss `process.env.NODE_ENV`, so check
 // both values to decide.
 
-const nodeEnv = typeof process !== 'undefined' ? process.env.NODE_ENV : undefined;
 const viteMode = typeof import.meta !== 'undefined' ? import.meta.env.MODE : undefined;
+const nodeEnv = typeof process !== 'undefined' ? process.env.NODE_ENV : undefined;
 
-export const IS_DEV = nodeEnv === 'development' || viteMode === 'development';
+export const IS_DEV = typeof viteMode !== 'undefined'
+  ? viteMode === 'development'
+  : nodeEnv === 'development';
 


### PR DESCRIPTION
## Summary
- fix the env variable logic so production builds don't call localhost

## Testing
- `npm run lint` *(fails: unexpected any etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866c574a848832d9f5b3b1d8766f6b5